### PR TITLE
2018q4: Add news about :

### DIFF
--- a/2018q4/arm64-rockchip.md
+++ b/2018q4/arm64-rockchip.md
@@ -1,0 +1,11 @@
+## RockChip Support
+
+Contact: Emmanuel Vadot <manu@FreeBSD.org>
+
+Early support for the RockChip RK3399 has been commited.
+For now it's only possible to netboot boards (Like the RockPro64).
+Original patch was submitted by Greg V <greg@unrelenting.technology>.
+
+Support for the RK805 and RK808 PMIC (Power Management IC) has been added.
+This allow changing some regulators voltage such as the cores one so cpufreq
+support works. You can change core freqeuncies with sysctl or powerd(8).

--- a/2018q4/dts.md
+++ b/2018q4/dts.md
@@ -1,0 +1,9 @@
+## DTS Update
+
+Contact: Emmanuel Vadot <manu@FreeBSD.org>
+
+DTS files (Device Tree Sources) were updated to be on par with Linux 4.20 for
+head and 4.19 for the 12-STABLE branch.
+
+The DTS are now compiled for some arm64 boards, as the one present in U-Boot are
+not always up-to-date.

--- a/2018q4/marvell.md
+++ b/2018q4/marvell.md
@@ -1,0 +1,11 @@
+## Marvell 8K SoC support
+
+Contact: Emmanuel Vadot <manu@FreeBSD.org>
+Contact: Luis Octavio O Souza <loos@FreeBSD.org>
+
+Support for booting FreeBSD on Marvell 8K SoC (present on the MacchiatoBin for example)
+has been commited.
+As of today clocks, gpio, thermal, sdcard/eMMC drivers has been commited.
+SATA and USB were already working.
+
+This work was sponsored by Rubicon Communications, LLC ("Netgate")

--- a/2018q4/pinebook.md
+++ b/2018q4/pinebook.md
@@ -1,0 +1,7 @@
+## Pinebook SDCard Image
+
+Contact: Emmanuel Vadot <manu@FreeBSD.org>
+
+SDCard image is now produced for the Pinebook.
+By default the console is directed in the EFI Framebuffer and the serial
+console.

--- a/2018q4/pwm.md
+++ b/2018q4/pwm.md
@@ -1,0 +1,8 @@
+## PWM Kernel API and userland utility
+
+Contact: Emmanuel Vadot <manu@FreeBSD.org>
+
+A new subsystem was added to the kernel for PWM drivers to register themselves.
+In pair with the kernel subsystem, a pwm(8) utility is also available so users
+can configure PWM on their embedded boards.
+For now the only PWM driver compatible with this subsystem is for ARM Allwinner SoCs.


### PR DESCRIPTION
- DTS Update in head and 12-stable
- Marvell 8K support
- RockChip RK3399 support
- Pinebook image
- PWM subsystem