### PR TITLE
sysctlview and sysctlmibinfo

### DIFF
--- a/2019q1/sysctlmibinfo.md
+++ b/2019q1/sysctlmibinfo.md
@@ -1,0 +1,23 @@
+## sysctlmibinfo API 1.0 ##
+
+Contact: Alfonso Sabato Siciliano, <alfonso.siciliano@email.com>
+
+Link:	 [gitlab.com/alfix/sysctlmibinfo](https://gitlab.com/alfix/sysctlmibinfo)  
+Port:	 [devel/libsysctlmibinfo](https://www.freshports.org/devel/libsysctlmibinfo/)
+
+The _sysctl()_ system call can get or set the value of a 'property' of the system. A 'property' has others info (description, type, label, etc.), they are necessary to build an utility like _/sbin/sysctl_, example:
+
+```
+% sysctl -d kern.ostype
+kern.ostype: Operating system type
+% sysctl -t kern.ostype
+kern.ostype: string
+```
+
+Primarily **sysctlmibinfo** wraps the undocumented kernel interface and provides an easy C API: *sysctlmif\_name()*, *sysctlmif\_description()*, *sysctlmif_info()*, *sysctlmif\_label()*, *sysctlmif\_nextnode()* and *sysctlmif\_nextleaf()*, to retrieve the info of a 'property'.
+
+Moreover **sysctlmibinfo** provides a high level API: defines a *struct sysctlmif\_object* and has some function: *sysctlmif\_filterlist()*, *sysctlmif\_grouplist()* and *sysctlmif\_tree()*,  to build lists and trees of *objects*. 
+
+You can use this library to build quickly a custom _sysctl_ utility. For example, the core of _deskutils/sysctlview_ (a graphical explorer for the sysctl MIB Tree) is just a call to *sysctlmif\_tree()* and a visit to the resulting tree to show its *sysctlmif\_object* nodes.
+
+Note, actually a 'property' is an OID of the sysctl MIB, it is implemented by a *struct sysctl\_oid* defined in *sys/sysctl.h*.

--- a/2019q1/sysctlview.md
+++ b/2019q1/sysctlview.md
@@ -1,0 +1,15 @@
+## sysctlview 1.0 ##
+
+Contact: Alfonso Sabato Siciliano, <alfonso.siciliano@email.com>
+
+Link:	 [gitlab.com/alfix/sysctlview](https://www.gitlab.com/alfix/sysctlview)  
+Port:	 [deskutils/sysctlview](https://www.freshports.org/deskutils/sysctlview/)
+
+The FreeBSD's kernel maintains a _Management Information Base_ where the _objects_ are properties to tunning the system using the _sysctl()_ syscall and the _/sbin/sysctl_ utility. The **sysctlview** utility is a "graphical sysctl MIB explorer", it depends on *gtkmm* (to build a GUI) and *sysctlmibinfo* (to retrieve the info from the kernel).
+
+The version 1.0 provides two "TreeView": 
+
+ - "Main" to show 'name', 'description', 'type', 'format' and 'value'
+ - "Flags" to show 'name' and a column for each 'flag' defined in *sys/sysctl.h*
+
+The rows are "clickable" to display others info (e.g., 'label'). Currently _sysctlview_ can show _numeric_ and _string_ values, the support for some _opaque_ value will be added in the future.


### PR DESCRIPTION
sysctlview is a gui tool to explore the FreeBSD sysctl-MIB,
sysctlmibinfo is an API to easily access to the FreeBSD sysctl-MIB.

I am not an English mother tongue, feel free to change/fix everything,
Thanks Alfonso