### PR TITLE
Add some correction and more info

### DIFF
--- a/2019q3/powerpc.md
+++ b/2019q3/powerpc.md
@@ -21,39 +21,47 @@ Key points:
 
 The main targeted platforms:
 
- - powerpc64 on IBM Power8 and Power9 chips (the most recent available).
+ - powerpc64 on IBM POWER8 and POWER9 chips (the most recent available).
    This is the primary focus going forward.  FreeBSD 12 is required;
    FreeBSD 13 is recommended.
 
  - powerpc64 on older Apple Power Macs, on a continuing but secondary
    basis.  Any FreeBSD version should work.
 
- - powerpc32 on x5000.  However, this is still developer-only quality.
+ - powerpc64 on x5000.  However, this is still developer-only quality.
    FreeBSD 13 is recommended.
+   
+ - powerpcspe on Amiga A1222.
 
 The software status:
 
- - powerpc64/12 and earlier still remain on the antiquated gcc4.2.1 in
+ - powerpc*/12 and earlier still remain on the antiquated gcc4.2.1 in
    base.
 
- - powerpc64/13 will soon be switched to llvm90 in base.  A great deal
+ - powerpc*/13 will soon be switched to llvm90 in base.  A great deal
    of work has been undertaken to ensure as few regressions as possible.
-   Once that switch has occurred (see llvm-elfv2 link above), powerpc64/13
+   Once that switch has occurred (see llvm-elfv2 link above), powerpc*/13
    support on gcc4.2.1 will no longer be a priority.
 
  - FreeBSD.org package sets are available for powerpc64/12 (quarterly)
    and powerpc64/13 (default) through the usual method.
+   
+ - Firefox works on powerpc64 using experimental (not-yet committed) patches,
 
  - As of the most recent package build on powerpc64/13 (still gcc4.2.1),
    the following statistics apply:
 
-   | Queued | Built | Failed | Skipped | Ignored | Remaining |
-   |--------|-------|--------|---------|---------|-----------|
-   | 33298  | 30361 | 259    | 1812    | 866     | 0         |
+   | Queued | Built | Failed | Skipped | Ignored |
+   |--------|-------|--------|---------|---------|
+   | 33306  | 30514 | 245    | 1686    | 861     |
 
  - More ports fixes are being committed every day.
 
-The team would like to thank IBM for the loan of two Power8 machines,
+The team would like to thank IBM for the loan of two POWER8 machines,
 and Oregon State University (OSU) for providing the hosting.  As well,
-we would like to thank the clusteradm team for keeping the Tyan Power8
+we would like to thank the clusteradm team for keeping the Tyan POWER8
 machines online that are hosted at [NYI](https://www.nyi.net).
+
+We would also like to thank FreeBSD Foundation for funding POWER9 workstation
+for one of the developers and Raptor Computer Systems for providing a remote
+POWER9 server for development purposes.


### PR DESCRIPTION
Package counts taken from http://pylon.nyi.freebsd.org/build.html?mastername=head-powerpc64-default&build=p515672_s354110

This run is already from Q4 but the previous counts were also from Q4. If you want the last run that finished in Q3, then it's here http://pylon.nyi.freebsd.org/build.html?mastername=head-powerpc64-default&build=p511848_s352239, but here numbers are much lower because of bad Poudriere's timeouts settings which were only recently fixed.