### PR TITLE
README.md typo and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FreeBSD quarterly status reports
+FreeBSD Quarterly Status Reports
 ================================
 
 ### Drafts
@@ -7,10 +7,10 @@ This repository is for drafts.
 
 Please submit your draft as early as possible. To submit:
 
-1. fork the repository – reusing an old fork is OK
-2. enter the directory for the current time period – `2019q4`
-3. create a new file, with a name that corresponds with the name of your project – use the `report-sample.md` template
-4. create a pull request.
+1. Fork the repository – reusing an old fork is OK.
+2. Enter the directory for the current time period – `2019q4`.
+3. Create a new file, with a name that corresponds with the name of your project – use the `report-sample.md` template.
+4. Create a pull request.
 
 You can tweak things afterwards. Simply edit, then submit another PR.
 
@@ -20,9 +20,12 @@ Please do not worry excessively about language errors or Markdown syntax – we 
 
 Wednesday 2020-01-01
 
-– immediately after the end of the fourth quarter. 
+Note that this is immediately after the end of the fourth
+quater, not several weeks later as was the case with previous quarterly
+reports.
 
-Deadlines now are tighter than in the past. Final reports will appear sooner. 
+Starting from this quarter reports will be collected the third month of each
+quarter. Then deadlines will be on the 1st of January, April, July, October.
 
 ### Finals
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,34 @@
-FreeBSD Quarterly Status Reports
+FreeBSD quarterly status reports
 ================================
 
-This is the working repo for FreeBSD Quarterly Status Reports.
-To submit your own report:
+### Drafts
 
-1. Fork the repository.  Reusing an old fork is fine
-2. Go into the directory for the current time period: `2019q4`
-3. Create a new file, with name corresponding to the
-   name of your project.  Please use the `report-sample.md`
-   as a template.
-4. Create a Pull Request
+This repository is for drafts. 
 
-Please submit your reports as early as you can.  You can tweak
-your report afterwards; just edit it and submit another PR.
+Please submit your draft as early as possible. To submit:
 
-Don't worry too much about the Markdown syntax or language errors - we
-will fix it for you.
+1. fork the repository – reusing an old fork is OK
+2. enter the directory for the current time period – `2019q4`
+3. create a new file, with a name that corresponds with the name of your project – use the `report-sample.md` template
+4. create a pull request.
 
-Deadline for submitting Status Reports for the fourth quarter of 2019
-is 2020-01-01.  (Note that this is immediately after the end of the fourth
-quater, not several weeks later as was the case with previous quarterly
-reports.)
+You can tweak things afterwards. Simply edit, then submit another PR.
+
+Please do not worry excessively about language errors or Markdown syntax – we can correct things for you.
+
+#### Deadline for submissions for `2019q4`
+
+Wednesday 2020-01-01
+
+– immediately after the end of the fourth quarter. 
+
+Deadlines now are tighter than in the past. Final reports will appear sooner. 
+
+### Finals
+
+Collated final reports are: 
+
+* listed at [FreeBSD Status Reports](https://www.freebsd.org/news/status/)
+* promoted through [newsflashes](https://www.freebsd.org/news/newsflash.html). 
+
+The most recent: https://www.freebsd.org/news/status/report-2019-07-2019-09.html

--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ Please do not worry excessively about language errors or Markdown syntax – we 
 
 Wednesday 2020-01-01
 
-Note that this is immediately after the end of the fourth
-quater, not several weeks later as was the case with previous quarterly
-reports.
+Note that this is **immediately** after the end of the quarter, not several weeks later as was the case with previous deadlines.
 
-Starting from this quarter reports will be collected the third month of each
-quarter. Then deadlines will be on the 1st of January, April, July, October.
+From this quarter onwards: 
+
+* Reports will be collected during the third month.
+* Deadlines will be the 1st of January, April, July and October.
 
 ### Finals
 
 Collated final reports are: 
 
-* listed at [FreeBSD Status Reports](https://www.freebsd.org/news/status/)
-* promoted through [newsflashes](https://www.freebsd.org/news/newsflash.html). 
+* Listed at [FreeBSD Status Reports](https://www.freebsd.org/news/status/).
+* Promoted through [newsflashes](https://www.freebsd.org/news/newsflash.html). 
 
-The most recent: https://www.freebsd.org/news/status/report-2019-07-2019-09.html
+The most recent report:
+
+* https://www.freebsd.org/news/status/report-2019-07-2019-09.html


### PR DESCRIPTION
### Additional suggestion

At the head of the home page of this repo: 

> FreeBSD quarterly reports

– expand the description: 

> FreeBSD quarterly status reports – drafts

– or simply: 

> FreeBSD quarterly status reports

### Nit (outside this repo)

https://www.freebsd.org/news/status/

> … due: January 1th, 2020

– should be: 

> … due: January 1st, 2020