### PR TITLE
README.md: improve readability for 80-col terminal editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,23 @@ This repository is for drafts.
 
 Please submit your draft as early as possible. To submit:
 
-1. Fork the repository – reusing an old fork is OK.
-2. Enter the directory for the current time period – `2019q4`.
-3. Create a new file, with a name that corresponds with the name of your project – use the `report-sample.md` template.
+1. Fork the repository - reusing an old fork is OK.
+2. Enter the directory for the current time period - `2019q4`.
+3. Create a new file, with a name that corresponds with the name of
+   your project - use the `report-sample.md` template.
 4. Create a pull request.
 
 You can tweak things afterwards. Simply edit, then submit another PR.
 
-Please do not worry excessively about language errors or Markdown syntax – we can correct things for you.
+Please do not worry excessively about language errors or Markdown
+syntax - we can correct things for you.
 
 #### Deadline for submissions for `2019q4`
 
 Wednesday 2020-01-01
 
-Note that this is **immediately** after the end of the quarter, not several weeks later as was the case with previous deadlines.
+Note that this is **immediately** after the end of the quarter, not
+several weeks later as was the case with previous deadlines.
 
 From this quarter onwards: 
 


### PR DESCRIPTION
- wrap to 72 columns (except URLs)
- replace en-dashes with hyphens