### PR TITLE
Light copyedit, the 20201005 edition.

### DIFF
--- a/2020q3/docng.md
+++ b/2020q3/docng.md
@@ -1,21 +1,21 @@
 ## DOCNG on FreeBSD ##
 
-Link:    [DOCNG Website Repo](https://gitlab.com/carlavilla/freebsd-hugo-website)  
-Link:    [DOCNG Documentation Repo](https://gitlab.com/carlavilla/freebsd-hugo-documentation)  
-Link:    [DOCNG Share Repo](https://gitlab.com/carlavilla/freebsd-hugo-data)  
+Link: [DOCNG Website Repo](https://gitlab.com/carlavilla/freebsd-hugo-website)
+Link: [DOCNG Documentation Repo](https://gitlab.com/carlavilla/freebsd-hugo-documentation)
+Link: [DOCNG Share Repo](https://gitlab.com/carlavilla/freebsd-hugo-data)
 
-Contact: Sergio Carlavilla <carlavilla@FreeBSD.org>  
+Contact: Sergio Carlavilla <carlavilla@FreeBSD.org>
 
 The Doc New Generation project aims to convert the website and all
 existing documentation to Hugo/AsciiDoctor. Right now almost
-everything it's converted as you can see in the repositories.
+everything is converted as you can see in the repositories.
 
-The objective of using Hugo and AsciiDoctor it's to reduce the
+The objective of using Hugo and AsciiDoctor is to reduce the
 learning curve and let people to start quickly with our documentation
 system. Other benefits of using Hugo is that we can use other
 technologies aside from AsciiDoctor, like MarkDown, RST, Pandoc, etc.
 
-The remaining of remaining things include:
+The remaining things include:
 - Finish the conversion of some books to AsciiDoctor,
 - Get some tweaks in our CSS to be responsive,
 - Some AsciiDoctor extensions to create an index of tables and figures,


### PR DESCRIPTION
Also removes NBSPs and spaces that I thought are spurious. Reinsert
at will.