### PR TITLE
fix typo

### DIFF
--- a/2021q1/sysctl-improvements.adoc
+++ b/2021q1/sysctl-improvements.adoc
@@ -1,12 +1,12 @@
 == sysctl improvements
 
-Link: https://gitlab.com/alfix/sysctlinfo[sysctlinfo]  
-Link: https://gitlab.com/alfix/sysctlbyname-improved[sysctlbyname-improved]  
-Link: https://git.io/Jm9x7[BSDCan 2020 - sysctlinfo questions]  
-Link: https://gitlab.com/alfix/sysctl-libnv[sysctl-libnv]  
-Link: https://gitlab.com/alfix/sysctlmibinfo2[sysctlmibinfo2]  
-Link: https://gitlab.com/alfix/sysctlview[sysctlview]  
-Link: https://gitlab.com/alfix/nsysctl[nsysctl]
+Link: link:https://gitlab.com/alfix/sysctlinfo[sysctlinfo]  +
+Link: link:https://gitlab.com/alfix/sysctlbyname-improved[sysctlbyname-improved]  +
+Link: link:https://git.io/Jm9x7[BSDCan 2020 - sysctlinfo questions]  +
+Link: link:https://gitlab.com/alfix/sysctl-libnv[sysctl-libnv]  +
+Link: link:https://gitlab.com/alfix/sysctlmibinfo2[sysctlmibinfo2]  +
+Link: link:https://gitlab.com/alfix/sysctlview[sysctlview]  +
+Link: link:https://gitlab.com/alfix/nsysctl[nsysctl]
 
 Contact: Alfonso Sabato Siciliano <alfonso.siciliano@email.com>
 
@@ -14,20 +14,20 @@ The sysctl system call and the wrapper sysctl utility can get and set the system
 After a recent system update with a CURRENT-GENERIC configuration, the MIB has exceeded ten thousand objects (both internal nodes and leaves, most in the vm.uma subtree) on my laptop with a Desktop environment without ZFS.
 Furthermore I received tips, ideas, PRs and iusses about sysctl so some improvement is been fulfilled, finally the suggestions received during the BSDCan 2020 are been accomplished.
 
-### Kernel space ###
-[sysctlinfo](https://freshports.org/ssysutils/sysctlinfo-kmod) has been updated to 20210222 and is an interface to visit the MIB and to retrieve info about an object (description, type, format, flags, and so on).
+=== Kernel space
+link:https://freshports.org/ssysutils/sysctlinfo-kmod[sysctlinfo] has been updated to 20210222 and is an interface to visit the MIB and to retrieve info about an object (description, type, format, flags, and so on).
 It is been refactored so the new version is almost 100% more efficient to explore the MIB and to pass all info about an object to userland.
 Moreover new features are been implemented: to get more info about an object, to avoid extra computation in userland and to improve the compatibilty with the current undocumented interface.
 
-[sysutils/sysctlbyname-improved](https://freshports.org/sysutils/sysctlbyname-improved-kmod) has been updated to 20210223 and is an extension of sysctlinfo to handle an object name with some empty string level or extetended to pass an input to the handler of a CTLTYPE_NODE; it is been updated to take advantages of the improvements (mainly efficiency) of sysctlinfo.
+link:https://freshports.org/sysutils/sysctlbyname-improved-kmod[sysutils/sysctlbyname-improved] has been updated to 20210223 and is an extension of sysctlinfo to handle an object name with some empty string level or extetended to pass an input to the handler of a CTLTYPE_NODE; it is been updated to take advantages of the improvements (mainly efficiency) of sysctlinfo.
 
-sysctl-libnv is a project that provides an implementation and an example of how to build a sysctl object with an nvlist value - to learn more about nvlist, see [the libnv(9) manual page](https://man.freebsd.org/libnv/9).
+sysctl-libnv is a project that provides an implementation and an example of how to build a sysctl object with an nvlist value - to learn more about nvlist, see the man:libnv[9] manual page.
 Properly a new sysctl handler is been defined: it is sufficient create a nvlist and to pass it to a macro then the system call uses the new handler to pass the nvlist to the userland and the nsysctl utility can manage the opject value.
 
 The following tools are been updated to give advantages from new kernel features and improvements.
 
-### Library ###
-sysctlmibinfo2 - port: devel/libsysctlmibinfo2 - updated to 2.0.1 + primarily the sysctlmibinfo2 library wraps the low level interfaces described above, moreover it defines a struct sysctlmif_object with the properties of an object and provides a convenient API to build data structures of sysctlmif_object (for example: a subtree, a list of a list of a Depth First
+=== Library
+link:https://freshports.org/devel/sysctlmibinfo2[devel/sysctlmibinfo2] has been updated to 2.1, primarily the sysctlmibinfo2 library wraps the low level interfaces described above, moreover it defines a struct sysctlmif_object with the properties of an object and provides a convenient API to build data structures of sysctlmif_object (for example: a subtree, a list of a list of a Depth First
 Traversal, and so on); therefore it is useful to handle an object correctly and/or to build a sysctl-like utility.
 
 Obviously sysctlmibinfo2 benefits of the features of sysctlinfo: handles OIDs up to CTL_MAXNAME levels, supports the Capability Mode, can seek an object matching its name (avoiding to explore the MIB just to find the corresponding OID), gets all info about an object in a time and manages a special name via sysctlbyname-improved.
@@ -35,17 +35,17 @@ Obviously sysctlmibinfo2 benefits of the features of sysctlinfo: handles OIDs up
 Version 2.0.1 takes the advantage from the kernel improvements: improved efficiency to build a sysctlmif_object and new features to get info about an object: "handler" and "nextbyname".
 The new functions are: sysctlmif_hashandler() and sysctlmif_hashandlerbyname() to know if an object has a defined kernel handler, sysctlmif_nextnodebyname() and sysctlmif_nextleafbyname() to explore the MIB, sysctlmif_leaves() and sysctlmif_leavesbyname() to build only-leaf data structures.
 
-### Documentation ###
+=== Documentation
 The APIs decribed above (both kernel and userspace) are really easy: "sysctl -aN", "sysctl -d kern.ostype", etc., can be implemented by few lines of code.
 Nevertheless each project provides a README with Introduction, Getting started, Features, API, Real world use cases, FAQ and examples in the Public Domain to build new projects.
 Of course the manuals and examples have recently been updated.
 
-### Utilities ###
-[sysctlview](https://freshports.org/sdeskutils/sysctlview] has been updated to 2.1 and is the first version of sysctlview was just a graphical representation of the MIB, now it could be considered a GUI version of sysctl.
+=== Utilities
+link:https://freshports.org/deskutils/sysctlview[deskutils/sysctlview] has been updated to 2.1, the first version of sysctlview was just a graphical representation of the MIB, now it could be considered a GUI version of sysctl.
 This utility exploits the object serialization of sysctlinfo, indeed it is not feasible to compel the kernel to find many time the same object to retrieve all its properties considering the current MIB size.
 Thanks to user feedbacks the new version provides a better UI, for example clicking a column title to sort the entries, moreover the "Handler" entry is been added in the "Object" window, it is useful to know if an object has a value or if the OID of a CTLTYPE_NODE can be extended.
 
-[nsysctl](https://freshports.org/ssysutils/nsysctl) has been updated to 2.0 and nsysctl is a terminal version of sysctlview, the output is explicitly indicated by the options and is printed via libxo in human and machine readable formats, moreover some string value is parsed to display structured output.
+link:https://freshports.org/sysutils/nsysctl[sysutils/nsysctl] has been updated to 2.0 and is a CLI version of sysctlview, the output is explicitly indicated by the options and is printed via libxo in human and machine readable formats, moreover some string value is parsed to display structured output.
 The options are not mutually exclusive and allow to show the properties of a parameter so nsysctl is useful to know the info to handle an object without to find its implementation, for example: Is Multiprocessor safe? Is Capability mode available? Is the OID extendible? Does the integer represent a kelvin? Does it have a value? What is the label? And so on.
 The new version supports libnv, it is useful to manage a non-primitive data type and could avoid hardcode of a generic opaque types in the future.
 Finally the new features of sysctlinfo allow to use nsysctl to debug the MIB without a kernel recompilation with SYSCTL_DEBUG.


### PR DESCRIPTION
Mainly fix freshport links typo, then uniform links and projects intro, finally fix adoc like https://github.com/freebsd/freebsd-quarterly/pull/346.