### PR TITLE
Last fixes

### DIFF
--- a/2021q1/_index.adoc
+++ b/2021q1/_index.adoc
@@ -1,10 +1,14 @@
+---
+title: "Introduction"
+sidenav: about
+---
+
 = Introduction
 :doctype: article
 :toc: macro
 :toclevels: 2
 :icons: font
-:sectnums:
-:sectnumlevels: 6
+:!sectnums:
 :source-highlighter: rouge
 :experimental:
 :reports-path: content/en/status/report-2021-01-2021-03
@@ -26,79 +30,125 @@ Daniel Ebdrup Jensen, with status hat on.
 
 toc::[]
 
+'''
+
 [[FreeBSD-Team-Reports]]
 == FreeBSD Team Reports
 
 Entries from the various official and semi-official teams, as found in the link:../../administration/[Administration Page].
 
-include::{reports-path}/freebsd-foundation.adoc[leveloffset=0]
+include::{reports-path}/freebsd-foundation.adoc[]
 
-include::{reports-path}/releng.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/clusteradm.adoc[leveloffset=0]
+include::{reports-path}/releng.adoc[]
 
-include::{reports-path}/ci.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/portmgr.adoc[leveloffset=0]
+include::{reports-path}/clusteradm.adoc[]
+
+'''
+
+include::{reports-path}/ci.adoc[]
+
+'''
+
+include::{reports-path}/portmgr.adoc[]
+
+'''
 
 [[projects]]
 == Projects
 
 Projects that span multiple categories, from the kernel and userspace to the Ports Collection or external projects.
 
-include::{reports-path}/git.adoc[leveloffset=0]
+include::{reports-path}/git.adoc[]
 
-include::{reports-path}/lldb.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/linuxulator.adoc[leveloffset=0]
+include::{reports-path}/lldb.adoc[]
 
-include::{reports-path}/mitigations.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/openbsm.adoc[leveloffset=0]
+include::{reports-path}/linuxulator.adoc[]
+
+'''
+
+include::{reports-path}/mitigations.adoc[]
+
+'''
+
+include::{reports-path}/openbsm.adoc[]
+
+'''
 
 [[kernel]]
 == Kernel
 
 Updates to kernel subsystems/features, driver support, filesystems, and more.
 
-include::{reports-path}/ena.adoc[leveloffset=0]
+include::{reports-path}/ena.adoc[]
 
-include::{reports-path}/iwlwifi.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/kernel-sanitizers.adoc[leveloffset=0]
+include::{reports-path}/iwlwifi.adoc[]
 
-include::{reports-path}/marvell.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/nv-sndstat.adoc[leveloffset=0]
+include::{reports-path}/kernel-sanitizers.adoc[]
+
+'''
+
+include::{reports-path}/marvell.adoc[]
+
+'''
+
+include::{reports-path}/nv-sndstat.adoc[]
+
+'''
 
 [[ports]]
 == Ports
 
 Changes affecting the Ports Collection, whether sweeping changes that touch most of the tree, or individual ports themselves.
 
-include::{reports-path}/kde.adoc[leveloffset=0]
+include::{reports-path}/kde.adoc[]
 
-include::{reports-path}/office.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/virtualbox.adoc[leveloffset=0]
+include::{reports-path}/office.adoc[]
+
+'''
+
+include::{reports-path}/virtualbox.adoc[]
+
+'''
 
 [[documentation]]
 == Documentation
 
 Noteworthy changes in the documentation tree, in manpages, or in external books/documents.
 
-include::{reports-path}/docng.adoc[leveloffset=0]
+include::{reports-path}/docng.adoc[]
 
-include::{reports-path}/weblate.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/www.adoc[leveloffset=0]
+include::{reports-path}/weblate.adoc[]
+
+'''
+
+include::{reports-path}/www.adoc[]
+
+'''
 
 [[miscellaneous]]
 == Miscellaneous
 
 Objects that defy categorization.
 
-include::{reports-path}/discord.adoc[leveloffset=0]
+include::{reports-path}/discord.adoc[]
+
+'''
 
 [[third-Party-Projects]]
 == Third-Party Projects
@@ -107,12 +157,20 @@ Many projects build upon FreeBSD or incorporate components of FreeBSD into their
 As these projects may be of interest to the broader FreeBSD community, we sometimes include brief updates submitted by these projects in our quarterly report.
 The FreeBSD project makes no representation as to the accuracy or veracity of any claims in these submissions.
 
-include::{reports-path}/cbsd.adoc[leveloffset=0]
+include::{reports-path}/cbsd.adoc[]
 
-include::{reports-path}/hellosystem.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/pkgbase.live.adoc[leveloffset=0]
+include::{reports-path}/hellosystem.adoc[]
 
-include::{reports-path}/potluck.adoc[leveloffset=0]
+'''
 
-include::{reports-path}/sysctl-improvements.adoc[leveloffset=0]
+include::{reports-path}/pkgbase.live.adoc[]
+
+'''
+
+include::{reports-path}/potluck.adoc[]
+
+'''
+
+include::{reports-path}/sysctl-improvements.adoc[]

--- a/2021q1/kernel-sanitizers.adoc
+++ b/2021q1/kernel-sanitizers.adoc
@@ -5,9 +5,9 @@ Contact: Mark Johnston <markj@FreeBSD.org>
 Work has been ongoing to port a pair of kernel sanitizers from NetBSD to FreeBSD.
 Sanitizers are debugging tools which make use of compiler instrumentation to validate memory accesses.
 They can automatically detect many classes of C programming bugs, such as use-after-frees and loads of uninitialized variables.
-When combined with [syzkaller](https://github.com/google/syzkaller) or other testing tools, they are effective at detecting kernel bugs that may otherwise require a great deal of manual effort to identify.
+When combined with link:https://github.com/google/syzkaller[syzkaller] or other testing tools, they are effective at detecting kernel bugs that may otherwise require a great deal of manual effort to identify.
 
-Two sanitizers are being ported, KASAN ([AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)) and KMSAN ([MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html)).
+Two sanitizers are being ported, KASAN (link:https://clang.llvm.org/docs/AddressSanitizer.html[AddressSanitizer]) and KMSAN (link:https://clang.llvm.org/docs/MemorySanitizer.html[MemorySanitizer]).
 KASAN checks the validity of all memory accesses within the kernel map and triggers a panic upon an out-of-bounds access or a use-after-free.
 Various kernel memory allocators annotate regions of memory to denote whether corresponding accesses are valid.
 The initial port of KASAN is complete and is planned to appear in the FreeBSD development branch in mid-April.

--- a/2021q1/marvell.adoc
+++ b/2021q1/marvell.adoc
@@ -13,10 +13,10 @@ Although the mentioned SoCs are mostly supported in FreeBSD HEAD, some pieces re
 
 Applied changes:
 
-* Add missing frequency modes in ap806_clock driver ([commit a86b0839d7bf](https://cgit.freebsd.org/src/commit/?id=a86b0839d7bf3fc06b1ae))
-* Multiple fixes in mvebu_gpio driver - in cooperation with mmel ([commit a5dce53b75d8](https://cgit.freebsd.org/src/commit/?id=a5dce53b75d8750ba))
-* Fix device tree data parsing in mv\_ap806\_gicp interrupt controller driver ([commit 622d17da46eb](https://cgit.freebsd.org/src/commit/?id=622d17da46eb360c3d684))
-* Rework the ICU interrupt controller (mv\_cp110\_icu) and its parent (mv\_ap806\_gicp), so that they no longer rely on the data provided by firmware, which fixes booting the OS from the newer U-Boot/TF-A revisions ([D28803](https://reviews.freebsd.org/D28803))
+* Add missing frequency modes in ap806_clock driver (link:https://cgit.freebsd.org/src/commit/?id=a86b0839d7bf3fc06b1ae[commit a86b0839d7bf])
+* Multiple fixes in mvebu_gpio driver - in cooperation with mmel (link:https://cgit.freebsd.org/src/commit/?id=a5dce53b75d8750ba[commit a5dce53b75d8])
+* Fix device tree data parsing in mv\_ap806\_gicp interrupt controller driver (link:https://cgit.freebsd.org/src/commit/?id=622d17da46eb360c3d684[commit 622d17da46eb])
+* Rework the ICU interrupt controller (mv\_cp110\_icu) and its parent (mv\_ap806\_gicp), so that they no longer rely on the data provided by firmware, which fixes booting the OS from the newer U-Boot/TF-A revisions (link:https://reviews.freebsd.org/D28803[D28803])
 * PCIE Designware driver (pci_dw) fixes:
 ** Correct setting of outbound I/O ATU window.
 ** Allow mapping ATU windows bigger than 4GB.

--- a/2021q1/releng.adoc
+++ b/2021q1/releng.adoc
@@ -1,7 +1,7 @@
 === FreeBSD Release Engineering Team
 
-Link:	[FreeBSD 13.0-RELEASE schedule](https://www.freebsd.org/releases/13.0R/schedule.html)
-Link:	[FreeBSD development snapshots](https://download.freebsd.org/ftp/snapshots/ISO-IMAGES/)
+Link:	link:https://www.freebsd.org/releases/13.0R/schedule.html[FreeBSD 13.0-RELEASE schedule] +
+Link:	link:https://download.freebsd.org/ftp/snapshots/ISO-IMAGES/[FreeBSD development snapshots]
 
 Contact: FreeBSD Release Engineering Team, <re@FreeBSD.org>
 


### PR DESCRIPTION
Fix links to use AsciiDoc syntax, add horizontal line between the different projects, remove leveloffset and fix the main title in the _index.adoc file