### PR TITLE
Add 2021Q3 entry for ZFS RAIDZ Expansion

### DIFF
--- a/2021q3/raidz-expansion.adoc
+++ b/2021q3/raidz-expansion.adoc
@@ -1,0 +1,29 @@
+=== OpenZFS RAIDZ Expansion update
+
+Contact: Matthew Ahrens <matt@mahrens.org>
+
+Links: +
+link:https://github.com/openzfs/zfs/pull/12225[OpenZFS Pull Request] URL: link:https://github.com/openzfs/zfs/pull/12225[https://github.com/openzfs/zfs/pull/12225] +
+link:https://www.youtube.com/watch?v=yF2KgQGmUic[video from 2021 FreeBSD Developer Summit] URL: link:https://www.youtube.com/watch?v=yF2KgQGmUic[https://www.youtube.com/watch?v=yF2KgQGmUic] +
+link:https://docs.google.com/presentation/d/1FeQgEwChrtNQBHfWSNsPK3Y53O5BnPh3Cz5nRa5GAQY/view[slides from 2021 FreeBSD Developer Summit] URL: link:https://docs.google.com/presentation/d/1FeQgEwChrtNQBHfWSNsPK3Y53O5BnPh3Cz5nRa5GAQY/view[https://docs.google.com/presentation/d/1FeQgEwChrtNQBHfWSNsPK3Y53O5BnPh3Cz5nRa5GAQY/view] +
+link:https://arstechnica.com/gadgets/2021/06/raidz-expansion-code-lands-in-openzfs-master/[news article from Ars Technica] URL: link:https://arstechnica.com/gadgets/2021/06/raidz-expansion-code-lands-in-openzfs-master/[https://arstechnica.com/gadgets/2021/06/raidz-expansion-code-lands-in-openzfs-master/]
+
+==== Project
+
+This feature allows disks to be added one at a time to a RAID-Z group, expanding its capacity incrementally.
+This feature is especially useful for small pools (typically with only one RAID-Z group), where there isn't sufficient hardware to add capacity by adding a whole new RAID-Z group (typically doubling the number of disks).
+
+FreeBSD's ZFS implementation comes from the OpenZFS project.
+This work will be integrated into the OpenZFS repo, with support for FreeBSD and Linux.
+
+==== Status
+
+The work is functionally complete, and a pull request has been opened.
+
+==== Remaining Work
+
+Remaining work includes some code cleanup, design documentation, addressing test failures.
+
+We also need to solicit code reviewers and respond to code review feedback.
+
+Sponsor: The FreeBSD Foundation


### PR DESCRIPTION
Since previous quarter's update: update video URL to link to specific talk rather than the whole stream.