### PR TITLE
2021q4: Remove reference to CI entry and prepare for release

### DIFF
--- a/2021q4/_index.adoc
+++ b/2021q4/_index.adoc
@@ -13,10 +13,10 @@ sidenav: about
 :experimental:
 :reports-path: content/en/status/report-2021-10-2021-12
 
-This report covers FreeBSD related projects for the period between October and December, and is the fourth of four planned reports for 2021, and contains !N entries.
+This report covers FreeBSD related projects for the period between October and December.  It is the fourth of four planned reports for 2021, and contains 19 entries.  Highlights include faster boot times, more LLDB work, a base OpenSSH update, and more wireless development.
 
 Yours, +
-Daniel Ebdrup Jensen, with status hat on.
+Pau Amma, Daniel Ebdrup, John-Mark Gurney, and Joe Mingrone
 
 '''
 
@@ -29,25 +29,91 @@ toc::[]
 
 Entries from the various official and semi-official teams, as found in the link:../../administration/[Administration Page].
 
+include::{reports-path}/freebsd-foundation.adoc[]
+
+'''
+
+include::{reports-path}/portmgr.adoc[]
+
+'''
+
+include::{reports-path}/doceng.adoc[]
+
+'''
+
+include::{reports-path}/www.adoc[]
+
+'''
+
 [[projects]]
 == Projects
 
 Projects that span multiple categories, from the kernel and userspace to the Ports Collection or external projects.
+
+
+include::{reports-path}/aslr.adoc[]
+
+'''
+
+include::{reports-path}/boot-performance.adoc[]
+
+'''
+
+include::{reports-path}/lldb.adoc[]
+
+'''
+
+include::{reports-path}/ls1027a.adoc[]
+
+'''
+
+include::{reports-path}/membarrier-rseq.adoc[]
+
+'''
+
+include::{reports-path}/openssh.adoc[]
+
+'''
+
+include::{reports-path}/vdso.adoc[]
+
+'''
 
 [[kernel]]
 == Kernel
 
 Updates to kernel subsystems/features, driver support, filesystems, and more.
 
+
+include::{reports-path}/avx-bug.adoc[]
+
+'''
+
+include::{reports-path}/ena.adoc[]
+
+'''
+
+include::{reports-path}/iwlwifi.adoc[]
+
+'''
+
+include::{reports-path}/ocf-wg.adoc[]
+
+'''
+
+
 [[ports]]
 == Ports
 
 Changes affecting the Ports Collection, whether sweeping changes that touch most of the tree, or individual ports themselves.
 
-[[miscellaneous]]
-== Miscellaneous
+include::{reports-path}/kde.adoc[]
 
-Objects that defy categorization.
+'''
+
+include::{reports-path}/office.adoc[]
+
+'''
 
 [[third-Party-Projects]]
 == Third-Party Projects
@@ -56,3 +122,10 @@ Many projects build upon FreeBSD or incorporate components of FreeBSD into their
 As these projects may be of interest to the broader FreeBSD community, we sometimes include brief updates submitted by these projects in our quarterly report.
 The FreeBSD project makes no representation as to the accuracy or veracity of any claims in these submissions.
 
+include::{reports-path}/hellosystem.adoc[]
+
+'''
+
+include::{reports-path}/pot.adoc[]
+
+'''

--- a/2021q4/aslr.adoc
+++ b/2021q4/aslr.adoc
@@ -21,7 +21,9 @@ in order to allow utilization of the bss grow region for mappings.
 It has no effect without ASLR, so it was applied to all architectures.
 
 TODO:
+
 * Improve stackgap feature implementation.
+
 * MFC to stable/13 branch.
 
 Sponsor: Stormshield

--- a/2021q4/aslr.adoc
+++ b/2021q4/aslr.adoc
@@ -12,11 +12,11 @@ security on its own, this mechanism can make exploitation more difficult.
 
 The Semihalf team made an effort to switch on the address map
 randomization for PIE (Position Independent Executables) & non-PIE 64-bit binaries.
-Once the https://cgit.freebsd.org/src/commit/?id=b014e0f15bc73d80e[patch] was merged to HEAD,
+Once the link:https://cgit.freebsd.org/src/commit/?id=b014e0f15bc73d80e[patch] was merged to HEAD,
 the ASLR feature became enabled for all 64-bit architectures.
 
 Additionally, the mentioned change disabled
-https://www.freebsd.org/cgi/man.cgi?query=sbrk&sektion=2[SBRK],
+link:https://www.freebsd.org/cgi/man.cgi?query=sbrk&sektion=2[SBRK],
 in order to allow utilization of the bss grow region for mappings.
 It has no effect without ASLR, so it was applied to all architectures.
 

--- a/2021q4/avx-bug.adoc
+++ b/2021q4/avx-bug.adoc
@@ -1,4 +1,4 @@
-== The AVX bug on amd64
+=== The AVX bug on amd64
 
 Commit: gitref:73b357be92385cbb70ba19e7023a736af2c6b493[repository=src] URL: link:https://cgit.freebsd.org/src/commit/?id=73b357be92385cbb70ba19e7023a736af2c6b493[https://cgit.freebsd.org/src/commit/?id=73b357be92385cbb70ba19e7023a736af2c6b493]
 

--- a/2021q4/avx-bug.adoc
+++ b/2021q4/avx-bug.adoc
@@ -1,8 +1,8 @@
 == The AVX bug on amd64
 
-Contact: Konstantin Belousov <kib@FreeBSD.org>
+Commit: gitref:73b357be92385cbb70ba19e7023a736af2c6b493[repository=src] URL: link:https://cgit.freebsd.org/src/commit/?id=73b357be92385cbb70ba19e7023a736af2c6b493[https://cgit.freebsd.org/src/commit/?id=73b357be92385cbb70ba19e7023a736af2c6b493]
 
-Commit: gitref:73b357be92385cbb70ba19e7023a736af2c6b493[repository=src]
+Contact: Konstantin Belousov <kib@FreeBSD.org>
 
 Some CPUs support the so called init optimization for XSAVE, but not all CPUs
 do.  And when they do, 'according to complex internal microarchitectural

--- a/2021q4/doceng.adoc
+++ b/2021q4/doceng.adoc
@@ -21,13 +21,9 @@ No new documentation commit bit was granted during the last quarter, and only on
 
 Several tasks were completed related to the doc tree during the last quarter:
 
-* A COPYRIGHT file was added in the root directory of the doc repository.
-+
-The license was also updated to reflect the current toolchain the project is using now.
+* A COPYRIGHT file was added in the root directory of the doc repository.  The license was also updated to reflect the current toolchain the project is using now.
 
-* Cleanup of Mailman information in the doc tree.
-+
-Following mailing lists migration from Mailman to Mlmmj, very old mailing lists were removed; most of the work was made on English documents.
+* Cleanup of Mailman information in the doc tree.  Following mailing lists migration from Mailman to Mlmmj, very old mailing lists were removed; most of the work was made on English documents.
 
 * Tag FreeBSD docset for 12.3-RELEASE.
 
@@ -35,9 +31,7 @@ Following mailing lists migration from Mailman to Mlmmj, very old mailing lists 
 
 * Move articles/contributors/contrib-* files to the doc shared directory.
 
-* Add option in documentation Makefile to archive/compress Documentation/HTML offline files, a necessary step before updating https://download.freebsd.org/ftp/.
-+
-Talking with clusteradm@ to update the offline assets (HTML/PDF).
+* Add option in documentation Makefile to archive/compress Documentation/HTML offline files, a necessary step before updating https://download.freebsd.org/ftp/.  This was after a discussion with clusteradm@ to update the offline assets (HTML/PDF).
 
 * Add experimental support for EPUB output (books/articles).
 

--- a/2021q4/doceng.adoc
+++ b/2021q4/doceng.adoc
@@ -8,9 +8,10 @@ Version:	$Id: doceng-2021-4th-quarter-status-report.adoc 208 2022-01-05 23:07:39
 
 === Documentation Engineering Team
 
-Link: link:https://www.freebsd.org/docproj/[FreeBSD Documentation Project] +
-Link: link:https://docs.freebsd.org/en/books/fdp-primer/[FreeBSD Documentation Project Primer for New Contributors] +
-Link: link:https://www.freebsd.org/administration/#t-doceng[Documentation Engineering Team]
+Links: +
+link:https://www.freebsd.org/docproj/[FreeBSD Documentation Project] URL: link:https://www.freebsd.org/docproj/[https://www.freebsd.org/docproj/] +
+link:https://docs.freebsd.org/en/books/fdp-primer/[FreeBSD Documentation Project Primer for New Contributors] URL: link:https://docs.freebsd.org/en/books/fdp-primer/[https://docs.freebsd.org/en/books/fdp-primer/] +
+link:https://www.freebsd.org/administration/#t-doceng[Documentation Engineering Team] URL: link:https://www.freebsd.org/administration/#t-doceng[https://www.freebsd.org/administration/#t-doceng]
 
 Contact: FreeBSD Doceng Team <doceng@FreeBSD.org>
 

--- a/2021q4/freebsd-foundation.adoc
+++ b/2021q4/freebsd-foundation.adoc
@@ -104,8 +104,6 @@ The Foundation provides a full-time staff member and funds projects to improve
 continuous integration, automated testing, and overall quality assurance efforts
 for the FreeBSD project.
 
-See the separate Continuous Integration entry for details.
-
 ==== Supporting FreeBSD Infrastructure
 
 The Foundation provides hardware and support for the Project.  In the fourth

--- a/2021q4/lldb.adoc
+++ b/2021q4/lldb.adoc
@@ -1,9 +1,9 @@
 === LLDB Debugger Improvements
 
 Links: +
-link:https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/[Moritz Systems Project Description] URL: link:https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/[link:https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/] +
-link:https://www.moritz.systems/blog/lldb-serial-port-communication-support/[Progress Report 3] URL: link:https://www.moritz.systems/blog/lldb-serial-port-communication-support/[link:https://www.moritz.systems/blog/lldb-serial-port-communication-support/] +
-link:https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/[Progress Report 4] URL: link:https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/[link:https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/] +
+link:https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/[Moritz Systems Project Description] URL: link:https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/[https://www.moritz.systems/blog/freebsd-kgdb-support-in-lldb/] +
+link:https://www.moritz.systems/blog/lldb-serial-port-communication-support/[Progress Report 3] URL: link:https://www.moritz.systems/blog/lldb-serial-port-communication-support/[https://www.moritz.systems/blog/lldb-serial-port-communication-support/] +
+link:https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/[Progress Report 4] URL: link:https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/[https://www.moritz.systems/blog/lldb-freebsd-kernel-core-dump-support/] +
 link:https://github.com/moritz-systems/llvm-project[LLVM Git Repository] URL: link:https://github.com/moritz-systems/llvm-project[https://github.com/moritz-systems/llvm-project] +
 link:https://github.com/moritz-systems/libfbsdvmcore[libfbsdvmcore Git Repository] URL: link:https://github.com/moritz-systems/libfbsdvmcore[https://github.com/moritz-systems/libfbsdvmcore]
 

--- a/2021q4/membarrier-rseq.adoc
+++ b/2021q4/membarrier-rseq.adoc
@@ -2,10 +2,11 @@
 
 Contact: Konstantin Belousov <kib@FreeBSD.org>
 
-Link: link:https://kib.kiev.ua/kib/membarrier.pdf[Linux manpage for membarrier(2)]
-Link: link:https://reviews.freebsd.org/D32360[membarrier(2) implementation]
-Link: link:https://kib.kiev.ua/kib/rseq.pdf[Linux manpage for rseq(2)]
-Link: link:https://reviews.freebsd.org/D32505[rseq(2) and userspace bindings implementation]
+Links: +
+link:https://kib.kiev.ua/kib/membarrier.pdf[Linux manpage for membarrier(2)] URL: link:https://kib.kiev.ua/kib/membarrier.pdf[https://kib.kiev.ua/kib/membarrier.pdf] +
+link:https://reviews.freebsd.org/D32360[membarrier(2) implementation] URL: link:https://reviews.freebsd.org/D32360[https://reviews.freebsd.org/D32360] +
+link:https://kib.kiev.ua/kib/rseq.pdf[Linux manpage for rseq(2)] URL: link:https://kib.kiev.ua/kib/rseq.pdf[https://kib.kiev.ua/kib/rseq.pdf] +
+link:https://reviews.freebsd.org/D32505[rseq(2) and userspace bindings implementation] URL: link:https://reviews.freebsd.org/D32505[https://reviews.freebsd.org/D32505]
 
 Linux provides a set of syscalls that allow to develop mostly
 syscall-less scalable algorithms in userspace.  The mechanisms are

--- a/2021q4/membarrier-rseq.adoc
+++ b/2021q4/membarrier-rseq.adoc
@@ -1,4 +1,4 @@
-== sched_getcpu(2), membarrier(2), and rseq(2) syscalls
+=== sched_getcpu(2), membarrier(2), and rseq(2) syscalls
 
 Contact: Konstantin Belousov <kib@FreeBSD.org>
 

--- a/2021q4/office.adoc
+++ b/2021q4/office.adoc
@@ -1,4 +1,4 @@
-=== FreeBSD Office team 2021Q4 status report
+=== FreeBSD Office Team
 
 Links: +
 link:https://wiki.freebsd.org/Office[The FreeBSD Office project] URL: link:https://wiki.freebsd.org/Office[https://wiki.freebsd.org/Office]

--- a/2021q4/portmgr.adoc
+++ b/2021q4/portmgr.adoc
@@ -1,7 +1,7 @@
 === Ports Collection
 
 Links: +
-link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL:link:https://www.FreeBSD.org/ports/[https://www.FreeBSD.org/ports/] +
+link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL: link:https://www.FreeBSD.org/ports/[https://www.FreeBSD.org/ports/] +
 link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[Contributing to Ports] URL: link:https://docs.freebsd.org/en/articles/contributing/#ports-contributing[https://docs.freebsd.org/en/articles/contributing/#ports-contributing] +
 link:http://portsmon.freebsd.org/[FreeBSD Ports Monitoring] URL: link:http://portsmon.freebsd.org/[http://portsmon.freebsd.org/] +
 link:https://www.freebsd.org/portmgr/[Ports Management Team] URL: link:https://www.freebsd.org/portmgr/[https://www.freebsd.org/portmgr/] +

--- a/2021q4/portmgr.adoc
+++ b/2021q4/portmgr.adoc
@@ -22,9 +22,13 @@ During the last quarter, we welcomed Dries Michiels (driesm@) and said goodbye t
 There was also a change in portmgr: adamw@ stepped down after five years of service and tcberner@ is now a full member of portmgr@.
 
 Three new USES were introduced:
+
 * magick to handle dependencies on ImageMagick
+
 * nodejs to provide support for NodeJS (with a new default version NODEJS=lts)
+
 * trigger to handle pkg triggers using the TRIGGERS variable
+
 The default version of PGSQL switched to 13.
 Furthermore, INSTALLS_ICONS has been replaced by a trigger on gtk-update-icon-cache and the macro is no longer functional.
 

--- a/2021q4/vdso.adoc
+++ b/2021q4/vdso.adoc
@@ -1,4 +1,4 @@
-== VDSO on amd64
+=== VDSO on amd64
 
 Contact: Konstantin Belousov <kib@FreeBSD.org>  
 


### PR DESCRIPTION
This report didn't get sent in, so remove the reference to it.