### PR TITLE
Add boot performance report

### DIFF
--- a/2021q4/boot-performance.adoc
+++ b/2021q4/boot-performance.adoc
@@ -14,10 +14,14 @@ enters the EC2 "running" state and when it is possible to SSH into the instance.
 This work started in 2017, and as of the end of September 2021 the FreeBSD boot
 time was reduced from approximately 30 seconds to approximately 15 seconds.
 
-During 2021Q4, a further 3 seconds of time has been shaved off the boot process,
-taking it down to roughly 9 seconds.  In addition, the userland boot process is
-now being profiled using TSLOG, making it possible to see flamecharts of the
-entire boot process.  A further 4 seconds of improvements are in process.
+During 2021Q4, further improvements have shaved more time off the boot process,
+taking it down to roughly 10 seconds.  A further 4 seconds of improvements are
+in process.
+
+In addition, the userland boot process is now being profiled using TSLOG,
+making it possible to see flamecharts of the entire boot process; and the
+ec2-boot-bench tool is now able to generate MP4 videos of the boot process
+by taking snapshots of the EC2 VGA console.
 
 Issues are listed on the wiki page as they are identified; the wiki page also
 has instructions for performing profiling.  Users are encouraged to profile

--- a/2021q4/boot-performance.adoc
+++ b/2021q4/boot-performance.adoc
@@ -1,0 +1,29 @@
+=== Boot Performance Improvements
+
+Links: +
+link:https://wiki.freebsd.org/BootTime[Wiki page] URL: link:https://wiki.freebsd.org/BootTime[https://wiki.freebsd.org/BootTime] +
+link:https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html[OS boot time comparison] URL: link:https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html[https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html]
+
+Contact: Colin Percival <cperciva@FreeBSD.org>
+
+Colin Percival is coordinating an effort to speed up the FreeBSD boot process.
+For benchmarking purposes, he is primarily using an EC2 c5.xlarge instance as a
+reference platform and is measuring the time between when the virtual machine
+enters the EC2 "running" state and when it is possible to SSH into the instance.
+
+This work started in 2017, and as of the end of September 2021 the FreeBSD boot
+time was reduced from approximately 30 seconds to approximately 15 seconds.
+
+During 2021Q4, a further 3 seconds of time has been shaved off the boot process,
+taking it down to roughly 9 seconds.  In addition, the userland boot process is
+now being profiled using TSLOG, making it possible to see flamecharts of the
+entire boot process.  A further 4 seconds of improvements are in process.
+
+Issues are listed on the wiki page as they are identified; the wiki page also
+has instructions for performing profiling.  Users are encouraged to profile
+the boot process on their own systems, in case they experience delays which
+don't show up on the system Colin is using for testing.
+
+This work is supported by Colin's FreeBSD/EC2 Patreon.
+
+Sponsor: https://www.patreon.com/cperciva

--- a/2022q1/boot-performance.adoc
+++ b/2022q1/boot-performance.adoc
@@ -1,0 +1,38 @@
+=== Boot Performance Improvements
+
+Links: +
+link:https://wiki.freebsd.org/BootTime[Wiki page] URL: link:https://wiki.freebsd.org/BootTime[https://wiki.freebsd.org/BootTime] +
+link:https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html[OS boot time comparison] URL: link:https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html[https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html]
+
+Contact: Colin Percival <cperciva@FreeBSD.org>
+
+Colin Percival is coordinating an effort to speed up the FreeBSD boot process.
+For benchmarking purposes, he is primarily using an EC2 c5.xlarge instance as a
+reference platform and is measuring the time between when the virtual machine
+enters the EC2 "running" state and when it is possible to SSH into the instance.
+
+This work started in 2017, and as of the end of December 2021 the FreeBSD boot
+time was reduced from approximately 30 seconds to approximately 10 seconds.
+During 2022Q1, further improvements have shaved more time off the boot process,
+taking it down to roughly 8 seconds.
+
+Two major issues remain outstanding:
+
+. The first time an EC2 instance boots, dhclient takes about 2 seconds longer
+than normal to get an IPv4 address.  The cause of this is unknown and requires
+investigation.
+
+. IPv6 configuration includes two one-second sleep(1) invocations, one from
+/etc/rc.d/netif and the other from /etc/rc.d/rtsold.  It might be possible to
+simply remove these; but care is needed to avoid progressing too far in the
+boot process before IPv6 addresses are configured.  Input from IPv6 experts
+is required here.
+
+Issues are listed on the wiki page as they are identified; the wiki page also
+has instructions for performing profiling.  Users are encouraged to profile
+the boot process on their own systems, in case they experience delays which
+don't show up on the system Colin is using for testing.
+
+This work is supported by Colin's FreeBSD/EC2 Patreon.
+
+Sponsor: https://www.patreon.com/cperciva


### PR DESCRIPTION
I'm not sure why github is showing commits from 2021Q4 in this PR... if there's something I should do to fix this please let me know.