### PR TITLE
KDE 2022q1 report, fixes

### DIFF
--- a/2022q1/kde.adoc
+++ b/2022q1/kde.adoc
@@ -28,6 +28,7 @@ This landed both in main and the last quarterly branch for 2021, since it brings
 * *graphics/digikam*, the digital photography manager, was updated to 7.6.0. (Thanks Dima Panov)
 * *graphics/kf5-kimageformats* has a new option enabling libheif and HEIC support.
 * *graphics/kontrast* was added to the 'accessibility' category. This is a tool for checking color-combinations (e.g. for a website) for sufficient contrast and readability.
+* *graphics/krita* was updated to the next big release, Krita 5. (Thanks Max Brazhnikov)
 * *lang/kross-interpreters* was fixed for Ruby 3. (Thanks Yasuhiro Kimura)
 * *sysutils/plasma5-discover* was updated to resolve some denial-of-service bugs in KDE infrastructure.
 * *www/falkon* was updated. After a two-year wait, a new release of the KDE web browser built on Qt WebEngine (itself a wrapper around Chromium internals) arrived upstream and in ports.

--- a/2022q1/kde.adoc
+++ b/2022q1/kde.adoc
@@ -11,21 +11,21 @@ The software includes a full desktop environment called KDE Plasma (for both X11
 
 The KDE team (kde@) is part of desktop@ and x11@ as well, building the software stack to make FreeBSD beautiful and usable as a daily-driver graphics-based desktop machine.
 
-*KDE Qt Patch Collection* The Qt Company did not release Qt 5.15 updates under Open Source licenses in 2020, leaving the Open Source 5.15 version lagging behind the proprietary release. Qt 6 is released under an Open Source license, but for the world of Open Source software that requires Qt 5, there is still a need for updates. The KDE Community fills that need by maintaining a curated set of patches -- generally backported from Qt6 -- to maintain the Open Source version of Qt 5. FreeBSD ports now use this *KDE Qt Patch Collection*, rather than the outdated last Qt 5.15.2 release from the Qt Company.
+*KDE Qt Patch Collection* The Qt Company did not release Qt 5.15 updates under Open Source licenses in 2021, leaving the Open Source 5.15 version lagging behind the proprietary release. Qt 6 is released under an Open Source license, but for the world of Open Source software that requires Qt 5, there is still a need for updates. The KDE Community fills that need by maintaining a curated set of patches -- generally backported from Qt6 -- to maintain the Open Source version of Qt 5. FreeBSD ports now use this *KDE Qt Patch Collection*, rather than the outdated last Qt 5.15.2 release from the Qt Company.
 This landed both in main and the last quarterly branch for 2021, since it brings important bugfixes.
 
 ==== KDE Stack
 
 * *KDE Plasma Desktop* (all the `*/plasma5-*` ports) was updated to 5.23.5 at the start of the year. Since this happened very shortly after quarterly was branched, this was MFH'ed. The long-term-support release 5.24 landed mid-february. The FreeBSD ports do not stick to LTS releases, and will follow the regular release schedule. 5.24.3 landed on schedule in March.
 * *KDE Gear* (the collection of KDE libraries and applicatious outside of the Frameworks and Plasma Desktop groups) was updated to 21.12.1 and MFH'ed. Monthy releases landed as well: 21.12.2 in February.
-* *KDE Frameworks* The frameworks have a monthly release cadence, so 5.90 landed in January, and 5.91 in February and 5.92 in March.
-* *KDE PIM* Because Google has changed the available REST API, KDE PIM currently does not support Contacts stored in a Google account.
+* *KDE Frameworks* have a monthly release cadence, so 5.90 landed in January, 5.91 in February and 5.92 in March.
+* *KDE PIM* currently does not support Contacts stored in a Google account because Google has changed the available REST API.
 * *astro/kstars* received its regularly scheduled updates.
 * *deskutils/kalendar* was updated. It has now reached the 1.0 stage.
 * *deskutils/kodaskanna* was added to the ports tree. It is a simple QR-code scanner for the desktop.
 * *deskutils/latte-dock* is an alternative launcher for use in KDE Plasma Desktop and other environments. It was updated to 0.10.7 as part of its monthly releases.
 * *devel/okteta*, an editor and viewer for binary data, was updated to 0.26.7, a regular bugfix release.
-* *graphics/digikam* the digital photography manager was updated to 7.6.0. (Thanks Dima Panov)
+* *graphics/digikam*, the digital photography manager, was updated to 7.6.0. (Thanks Dima Panov)
 * *graphics/kf5-kimageformats* has a new option enabling libheif and HEIC support.
 * *graphics/kontrast* was added to the 'accessibility' category. This is a tool for checking color-combinations (e.g. for a website) for sufficient contrast and readability.
 * *lang/kross-interpreters* was fixed for Ruby 3. (Thanks Yasuhiro Kimura)

--- a/2022q1/kde.adoc
+++ b/2022q1/kde.adoc
@@ -11,16 +11,38 @@ The software includes a full desktop environment called KDE Plasma (for both X11
 
 The KDE team (kde@) is part of desktop@ and x11@ as well, building the software stack to make FreeBSD beautiful and usable as a daily-driver graphics-based desktop machine.
 
-*KDE Qt Patch Collection* The Qt Company stopped releasing Qt 5.15 updates under Open Source licenses in 2020. Qt 6 is now released under an Open Source license, but for the world of Open Source software that requires Qt 5, there is still a need for updates. The KDE Community fills that need by maintaining a curated set of patches -- generally backported from Qt6 -- to maintain the Open Source version of Qt 5. FreeBSD ports now use this *KDE Qt Patch Collection*, rather than the outdated last Qt 5.15.2 release from the Qt Company.
+*KDE Qt Patch Collection* The Qt Company did not release Qt 5.15 updates under Open Source licenses in 2020, leaving the Open Source 5.15 version lagging behind the proprietary release. Qt 6 is released under an Open Source license, but for the world of Open Source software that requires Qt 5, there is still a need for updates. The KDE Community fills that need by maintaining a curated set of patches -- generally backported from Qt6 -- to maintain the Open Source version of Qt 5. FreeBSD ports now use this *KDE Qt Patch Collection*, rather than the outdated last Qt 5.15.2 release from the Qt Company.
 This landed both in main and the last quarterly branch for 2021, since it brings important bugfixes.
 
 ==== KDE Stack
 
-* *KDE Plasma Desktop* (all the `*/plasma5-*` ports) was updated to 5.23.5 at the start of the year. Since this happened very shortly after quarterly was branched, this was MFH'ed.
-* *KDE Gear* (the collection of KDE libraries and applicatious outside of the Frameworks and Plasma Desktop groups) was updated to 21.12.1 and MFH'ed.
+* *KDE Plasma Desktop* (all the `*/plasma5-*` ports) was updated to 5.23.5 at the start of the year. Since this happened very shortly after quarterly was branched, this was MFH'ed. The long-term-support release 5.24 landed mid-february. The FreeBSD ports do not stick to LTS releases, and will follow the regular release schedule. 5.24.3 landed on schedule in March.
+* *KDE Gear* (the collection of KDE libraries and applicatious outside of the Frameworks and Plasma Desktop groups) was updated to 21.12.1 and MFH'ed. Monthy releases landed as well: 21.12.2 in February.
+* *KDE Frameworks* The frameworks have a monthly release cadence, so 5.90 landed in January, and 5.91 in February and 5.92 in March.
+* *KDE PIM* Because Google has changed the available REST API, KDE PIM currently does not support Contacts stored in a Google account.
+* *astro/kstars* received its regularly scheduled updates.
+* *deskutils/kalendar* was updated. It has now reached the 1.0 stage.
+* *deskutils/kodaskanna* was added to the ports tree. It is a simple QR-code scanner for the desktop.
+* *deskutils/latte-dock* is an alternative launcher for use in KDE Plasma Desktop and other environments. It was updated to 0.10.7 as part of its monthly releases.
+* *devel/okteta*, an editor and viewer for binary data, was updated to 0.26.7, a regular bugfix release.
+* *graphics/digikam* the digital photography manager was updated to 7.6.0. (Thanks Dima Panov)
+* *graphics/kf5-kimageformats* has a new option enabling libheif and HEIC support.
+* *graphics/kontrast* was added to the 'accessibility' category. This is a tool for checking color-combinations (e.g. for a website) for sufficient contrast and readability.
+* *lang/kross-interpreters* was fixed for Ruby 3. (Thanks Yasuhiro Kimura)
+* *sysutils/plasma5-discover* was updated to resolve some denial-of-service bugs in KDE infrastructure.
+* *www/falkon* was updated. After a two-year wait, a new release of the KDE web browser built on Qt WebEngine (itself a wrapper around Chromium internals) arrived upstream and in ports.
+* *x11/plasma5-plasma-workspace* now can properly edit login and account information.
 
 
 ==== Related Applications
 
-* *net-im/nheko* was updated. This is one of a dozen Matrix clients available in the ports tree.
+* *devel/qtcreator* was updated to version 6. A new versioning model has been introduced by upstream, so this will now jump by major release number regularly. (Thanks to Florian Walpen)
 * *irc/quassel* was updated. Quassel is a distributed IRC client (think of it as your own personal IRC bouncer).
+* *misc/tellico* was updated. Tellico is a "collection manager", for instance collections of books, music, stamps, or FreeBSD releases.
+* *net-im/nheko* was updated. This is one of a dozen Matrix clients available in the ports tree.
+
+=== Elsewhere
+
+* *archivers/7-zip* is the preferred tool for dealing with 7zip files; this affacts KDE applications that work with archives (like *archivers/ark*). We would like to thank makc@ for stewarding that update.
+* *devel/libphonenumber* has bi-weekly updates to chase the exciting world of telephony details.
+* *graphics/poppler* was updated to version 22.01. This version requires C++17, which pushes a number of consumers to the newer C++ standard as well. Most consumers were fixed in advance.


### PR DESCRIPTION
This fills out the rest of the quarter (a stub was merged in january)