### PR TITLE
2022q1/Makefile: Add file

### DIFF
--- a/2022q1/Makefile
+++ b/2022q1/Makefile
@@ -12,10 +12,10 @@ TeamReports= freebsd-foundation.adoc releng.adoc clusteradm.adoc ci.adoc portmgr
 
 # Projects that span multiple categories, from the kernel, and userspace to
 # the Ports Collection or external projects
-Projects= accessibility.adoc
+Projects= accessibility.adoc boot-performance.adoc
 
 # Changes affecting the base system and programs in it
-Userland= boot-performance.adoc
+Userland=
 
 # Updates to kernel subsystems/features, driver support, filesystems,
 # and more
@@ -31,13 +31,13 @@ Documentation=	doceng.adoc
 
 # Changes affecting the Ports Collection, whether sweeping changes that
 # touch most of the tree, or individual ports themselves
-Ports= kde.adoc office.adoc gcc.adoc portconfig.adoc fpart.adoc wifibox.adoc
+Ports= kde.adoc office.adoc gcc.adoc portconfig.adoc wifibox.adoc
 
 # Third party project built on FreeBSD, but not part of the FreeBSD
 # project itself
-ThirdParty=
+ThirdParty= hellosystem.adoc pot.adoc fpart.adoc
 
 # Objects that defy categorization
-Miscellaneous= hellosystem.adoc pot.adoc
+Miscellaneous=
 
 .include <../tools/Makefile>

--- a/2022q1/Makefile
+++ b/2022q1/Makefile
@@ -8,7 +8,7 @@ YEAR?=		2022
 QUARTER?=	1
 
 # Entries from the various official and semi-official teams
-TeamReports= FreeBSD-Foundation.adoc releng.adoc clusteradm.adoc ci.adoc portmgr.adoc
+TeamReports= freebsd-foundation.adoc releng.adoc clusteradm.adoc ci.adoc portmgr.adoc
 
 # Projects that span multiple categories, from the kernel, and userspace to
 # the Ports Collection or external projects

--- a/2022q1/Makefile
+++ b/2022q1/Makefile
@@ -1,0 +1,43 @@
+# Report month start
+START?=		1
+# Report month end
+STOP?=		3
+# Report year
+YEAR?=		2022
+# Report quarter
+QUARTER?=	1
+
+# Entries from the various official and semi-official teams
+TeamReports= FreeBSD-Foundation.adoc releng.adoc clusteradm.adoc ci.adoc portmgr.adoc
+
+# Projects that span multiple categories, from the kernel, and userspace to
+# the Ports Collection or external projects
+Projects= accessibility.adoc
+
+# Changes affecting the base system and programs in it
+Userland= boot-performance.adoc
+
+# Updates to kernel subsystems/features, driver support, filesystems,
+# and more
+Kernel= ena.adoc gunion.adoc rtw88.adoc iwlwifi.adoc ocf-wg.adoc
+
+# Updating platform-specific features and bringing in support for new
+# hardware platforms
+Architectures= dpaa2.adoc
+
+# Noteworthy changes in the documentation tree, man-pages, or new
+# external books/documents
+Documentation=	doceng.adoc
+
+# Changes affecting the Ports Collection, whether sweeping changes that
+# touch most of the tree, or individual ports themselves
+Ports= kde.adoc office.adoc gcc.adoc portconfig.adoc fpart.adoc wifibox.adoc
+
+# Third party project built on FreeBSD, but not part of the FreeBSD
+# project itself
+ThirdParty=
+
+# Objects that defy categorization
+Miscellaneous= hellosystem.adoc pot.adoc
+
+.include <../tools/Makefile>


### PR DESCRIPTION
New tools are being developed to generate reports automatically. This commit creates a Makefile for the 2022q1 quarterly report, in the same style as in the past.

Please review if I inserted each report in the right category and if you agree with the order. Feel free to change whatever you believe should be changed.