### PR TITLE
Remove my/specific mention

### DIFF
--- a/2022q1/portmgr.adoc
+++ b/2022q1/portmgr.adoc
@@ -27,7 +27,7 @@ The last quarter saw 9,403 commits to the main branch by 157 committers and 683 
 Compared to last quarter, this means a slight drop in activity to the main branch and a slight
 increase in the number of open PRs.
 
-No new committers joined during the last quarter, portmgr took koobs@' commit bit in for safekeeping because of a lack of recent commits.
+No new committers joined during the last quarter, portmgr took one commit bit in for safekeeping because of a lack of recent commits.
 
 The cluster administration team has provided portmgr with a third aarch64 builder; it is being used for package builds.
 


### PR DESCRIPTION
This entry does not include context preceded the action to remove
my commit bit. It has further put me in an uncomfortable position
where I have now been asked several times about it.

Accordingly replace specific mention with a count
of commit bits (one) that were taken in.