### PR TITLE
2022q2: superpages.adoc: Add report about medium-sized superpages

### DIFF
--- a/2022q2/igt-gpu-tools.adoc
+++ b/2022q2/igt-gpu-tools.adoc
@@ -1,4 +1,4 @@
-Engineer a Feature Complete Port of Intel's igt-gpu-tools for FreeBSD
+=== Feature Complete Port of Intel's igt-gpu-tools
 
 Links: +
 link:https://wiki.freebsd.org/SummerOfCode2022Projects/ImprovingTheLinuxKPICompatibilityLayerForTheFreeBSDGraphicsStack/[FreeBSD Wiki Project Page] URL:

--- a/2022q2/superpages.adoc
+++ b/2022q2/superpages.adoc
@@ -1,0 +1,14 @@
+=== Medium-sized superpages on arm64 and beyond
+
+Contact: Eliot H. Solomon <ehs3@rice.edu> +
+Contact: Alan L. Cox <alc@rice.edu> +
+
+Recent iterations of the 64-bit ARM architecture's virtual memory subsystem include support for the Contiguous bit, which tells the hardware to cache using only one TLB entry an aligned, physically contiguous group of sixteen page table entries which have identical permissions and attributes. 
+
+This feature, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sizes superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
+
+This project focuses on bringing support for medium-sized superpages to FreeBSD. So far, we have modified the arm64 pmap code to automatically utilize 64 KiB superpages by detecting physically contiguous page table entries and promoting them using the Contiguous bit. Now, we are working to adapt the kernel's superpage reservation module to support 64 KiB reservations in addition to the current 2 MiB ones. Adding medium-sized reservations will allow the virtual memory system to explicitly allocate pieces of memory which fit the requirements for superpage promotion, rather than just hoping that they occur by chance.
+
+Our goal is to accomplish this in a general way that makes it possible to specify multiple arbitrary power-of-two reservation sizes, making it easier to take advantage of hardware features on other architectures like Ryzen's PTE Coalescing, which transparently merges groups of 4 KiB page table entries into 32 KiB medium-sized superpages. 
+
+Sponsor: Department of Computer Science, Rice University

--- a/2022q2/superpages.adoc
+++ b/2022q2/superpages.adoc
@@ -3,9 +3,9 @@
 Contact: Eliot H. Solomon <ehs3@rice.edu> +
 Contact: Alan L. Cox <alc@rice.edu> +
 
-Recent iterations of the 64-bit ARM architecture's virtual memory subsystem include support for the Contiguous bit, which tells the hardware to cache using only one TLB entry an aligned, physically contiguous group of sixteen page table entries which have identical permissions and attributes. 
+The 64-bit ARM architecture's page table descriptor format contains a flag called the Contiguous bit. This tells the hardware to cache an aligned, physically contiguous group of 16 page table entries which have identical permissions and attributes using only 1 TLB entry if possible. 
 
-This feature, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sizes superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
+The Contiguous bit, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sizes superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
 
 This project focuses on bringing support for medium-sized superpages to FreeBSD. So far, we have modified the arm64 pmap code to automatically utilize 64 KiB superpages by detecting physically contiguous page table entries and promoting them using the Contiguous bit. Now, we are working to adapt the kernel's superpage reservation module to support 64 KiB reservations in addition to the current 2 MiB ones. Adding medium-sized reservations will allow the virtual memory system to explicitly allocate pieces of memory which fit the requirements for superpage promotion, rather than just hoping that they occur by chance.
 

--- a/2022q2/superpages.adoc
+++ b/2022q2/superpages.adoc
@@ -3,12 +3,12 @@
 Contact: Eliot H. Solomon <ehs3@rice.edu> +
 Contact: Alan L. Cox <alc@rice.edu> +
 
-The 64-bit ARM architecture's page table descriptor format contains a flag called the Contiguous bit. This tells the hardware to cache an aligned, physically contiguous group of 16 page table entries which have identical permissions and attributes using only 1 TLB entry if possible. 
+The 64-bit ARM architecture's page table descriptor format contains a flag called the Contiguous bit. This tells the MMU that it can cache an aligned, physically contiguous group of 16 page table entries which have identical permissions and attributes using only 1 TLB entry. 
 
 The Contiguous bit, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sizes superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
 
 This project focuses on bringing support for medium-sized superpages to FreeBSD. So far, we have modified the arm64 pmap code to automatically utilize 64 KiB superpages by detecting physically contiguous page table entries and promoting them using the Contiguous bit. Now, we are working to adapt the kernel's superpage reservation module to support 64 KiB reservations in addition to the current 2 MiB ones. Adding medium-sized reservations will allow the virtual memory system to explicitly allocate pieces of memory which fit the requirements for superpage promotion, rather than just hoping that they occur by chance.
 
-Our goal is to accomplish this in a general way that makes it possible to specify multiple arbitrary power-of-two reservation sizes, making it easier to take advantage of hardware features on other architectures like Ryzen's PTE Coalescing, which transparently merges groups of 4 KiB page table entries into 32 KiB medium-sized superpages. 
+Our goal is to accomplish this in a general way that makes it possible to specify multiple arbitrary power-of-two reservation sizes, making it easier to take advantage of hardware features on other architectures like Ryzen's PTE Coalescing, which transparently merges groups of 4 KiB page table entries into medium-sized superpages. 
 
 Sponsor: Department of Computer Science, Rice University

--- a/2022q2/superpages.adoc
+++ b/2022q2/superpages.adoc
@@ -5,7 +5,7 @@ Contact: Alan L. Cox <alc@rice.edu> +
 
 The 64-bit ARM architecture's page table descriptor format contains a flag called the Contiguous bit. This tells the MMU that it can cache an aligned, physically contiguous group of 16 page table entries which have identical permissions and attributes using only 1 TLB entry. 
 
-The Contiguous bit, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sizes superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
+The Contiguous bit, as well as the conceptually similar Svnapot extension to the RISC-V architecture, allows for the use of 64 KiB superpages. These medium-sized superpages can bring to smaller memory objects the address-translation speedup typically associated with more traditional 2 MiB superpages.
 
 This project focuses on bringing support for medium-sized superpages to FreeBSD. So far, we have modified the arm64 pmap code to automatically utilize 64 KiB superpages by detecting physically contiguous page table entries and promoting them using the Contiguous bit. Now, we are working to adapt the kernel's superpage reservation module to support 64 KiB reservations in addition to the current 2 MiB ones. Adding medium-sized reservations will allow the virtual memory system to explicitly allocate pieces of memory which fit the requirements for superpage promotion, rather than just hoping that they occur by chance.
 


### PR DESCRIPTION
This report explains a project that will bring medium-sized superpage support to FreeBSD on 64-bit ARM systems. Any feedback is welcome!