### PR TITLE
portmgr.adoc: AsciiDoc, grammar, punctuation

### DIFF
--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -13,7 +13,7 @@ Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
 Below is what happened in the last quarter.
 
-Freshports tells us the number of ports grew to over 50,000, a new milestone.
+FreshPorts tells us the number of ports grew to over 50,000, a new milestone.
 The last quarter saw 9,137 commits by 151 committers on the "main" and 589 commits by 61 committers on the "2022Q2" branch.
 At the time of writing, there are 2,700 open ports PRs of which 682 are unassigned.
 Compared to the previous quarter, the Ports Tree grew by 7%, a slight decrease in commit activity and a constant number of PRs.

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -31,5 +31,5 @@ Following a discussion among developers, portmgr decided to grant all documentat
 The following changes were made to the Ports Tree during 2022q2:
 
 * pkg got updated to version 1.18.3, Firefox to version 102.0 and Chromium to version 103.0.50060.53
-* deault versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0
+* default versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0
 * two new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -1,4 +1,4 @@
-=== Ports Collection
+=== Ports Management
 
 Links: +
 link:https://www.FreeBSD.org/ports/[About FreeBSD Ports] URL:link:https://www.FreeBSD.org/ports/[https://www.FreeBSD.org/ports/] +

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -10,15 +10,14 @@ link:http://ftp.freebsd.org/pub/FreeBSD/ports/ports/[Ports Tarball] URL: link:ht
 Contact: René Ladan <portmgr-secretary@FreeBSD.org> +
 Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 
-The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
-Below is what happened in the last quarter.
+Responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
 
-FreshPorts tells us the number of ports grew to over 50,000, a new milestone.
-The last quarter saw 9,137 commits by 151 committers on the "main" and 589 commits by 61 committers on the "2022Q2" branch.
+FreshPorts tells us that the number of ports grew to over 50,000, a new milestone.
+There were 9,137 commits by 151 committers on the "main" and 589 commits by 61 committers on the "2022Q2" branch.
 At the time of writing, there are 2,700 open ports PRs of which 682 are unassigned.
-Compared to the previous quarter, the Ports Tree grew by 7%, a slight decrease in commit activity and a constant number of PRs.
+The Ports Tree grew by seven percent, a slight decrease in commit activity and a constant number of PRs.
 
-During the last quarter, portmgr welcomed back salvadore@ but also said goodbye to seven ports committers due to lack of activity.
+portmgr welcomed back salvadore@ but also said goodbye to seven ports committers due to lack of activity.
 
 In its bi-weekly meetings, portmgr discussed the following topics:
 
@@ -28,7 +27,7 @@ In its bi-weekly meetings, portmgr discussed the following topics:
 
 Following a discussion among developers, portmgr decided to grant all documentation and source committers approval to fix any documentation-related error in the Ports Tree which does not affect its functionality.
 
-The following changes were made to the Ports Tree during 2022q2:
+Changes to the Ports Tree:
 
 * pkg got updated to version 1.18.3, Firefox to version 102.0 and Chromium to version 103.0.50060.53
 * default versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -24,12 +24,12 @@ In its bi-weekly meetings, portmgr discussed the following topics:
 
 * the future of ca_root_nss
 * feasibility of the base system providing certain .pc files
-* ways to deal with incompatibilities in kernel module ports on minor version upgrades of the base system
+* ways to deal with incompatibilities in kernel module ports on minor version upgrades of the base system. 
 
 Following a discussion among developers, portmgr decided to grant all documentation and source committers approval to fix any documentation-related error in the Ports Tree which does not affect its functionality.
 
 The following changes were made to the Ports Tree during 2022q2:
 
 * pkg got updated to version 1.18.3, Firefox to version 102.0 and Chromium to version 103.0.50060.53
-* Default versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0.
-* Two new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.
+* deault versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0
+* to new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -32,4 +32,4 @@ The following changes were made to the Ports Tree during 2022q2:
 
 * pkg got updated to version 1.18.3, Firefox to version 102.0 and Chromium to version 103.0.50060.53
 * deault versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0
-* to new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.
+* two new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.

--- a/2022q2/portmgr.adoc
+++ b/2022q2/portmgr.adoc
@@ -18,18 +18,18 @@ The last quarter saw 9,137 commits by 151 committers on the "main" and 589 commi
 At the time of writing, there are 2,700 open ports PRs of which 682 are unassigned.
 Compared to the previous quarter, the Ports Tree grew by 7%, a slight decrease in commit activity and a constant number of PRs.
 
-During the last quarter, portmgr
-welcomed back salvadore@ but also said goodbye to seven ports committers due to lack of activity.
+During the last quarter, portmgr welcomed back salvadore@ but also said goodbye to seven ports committers due to lack of activity.
 
 In its bi-weekly meetings, portmgr discussed the following topics:
+
 * the future of ca_root_nss
 * feasibility of the base system providing certain .pc files
 * ways to deal with incompatibilities in kernel module ports on minor version upgrades of the base system
 
-Following a discussion among developers, portmgr decided to grant all documentation and source
-committers approval to fix any documentation-related error in the Ports Tree which does not affect its functionality.
+Following a discussion among developers, portmgr decided to grant all documentation and source committers approval to fix any documentation-related error in the Ports Tree which does not affect its functionality.
 
 The following changes were made to the Ports Tree during 2022q2:
+
 * pkg got updated to version 1.18.3, Firefox to version 102.0 and Chromium to version 103.0.50060.53
 * Default versions of GCC, Lazarus, Python and Ruby got updated to respectively 11 (powerpcspe keeps version 8), 2.2.2, 3.9, and 3.0.
 * Two new USES were added, gstreamer to support ports based on GStreamer plugins and pytest to help testing with pytest.


### PR DESCRIPTION
It seems that the first line in a list must be **non-consecutive** to the previous line of text. 

In other words: blank lines are required.