### PR TITLE
2022q3/calendar-data.adoc: Add report

### DIFF
--- a/2022q3/calendar-data.adoc
+++ b/2022q3/calendar-data.adoc
@@ -1,0 +1,20 @@
+=== Calendar-data: License added
+
+Links +
+link:https://github.com/freebsd/calendar-data[GitHub calendar-data repository] URL:
+link:https://github.com/freebsd/calendar-data[https://github.com/freebsd/calendar-data] +
+
+Contact: Stefan Eßer <se@FreeBSD.org> +
+Contact: Lorenzo Salvadore <salvadore@FreeBSD.org> +
+Contact: Warner Losh <imp@FreeBSD.org>
+
+The port deskutils/calendar-data contains calendar files for the BSD calendar program and is maintained by se@.
+The data for this port lives in a link:https://github.com/freebsd/calendar-data[GitHub repository], which at the moment is maintained mainly by salvadore@.
+
+About two years ago, the calendar files in the base repository where removed from there and a new link:https://github.com/freebsd/calendar-data[repository] was created on GitHub; see also this link:https://reviews.freebsd.org/D26883[Phabricator review] about the creation of the associated port.
+This improvement allows calendar files to be updated indipendently from the base system.
+
+Unfortunately, when the repository was created, it was forgotten to add a license to it.
+The issue has been solved this quarter with this link:https://github.com/freebsd/calendar-data/pull/9[pull request] submitted by salvadore@ and merged by imp@.
+Since the data originally came from the src repository, the same licence applies.
+If in the past you have contributed to the calendar files with different licensing assumptions, please inform us so that we can license your contributions accordingly or remove them.

--- a/2022q3/calendar-data.adoc
+++ b/2022q3/calendar-data.adoc
@@ -11,8 +11,8 @@ Contact: Warner Losh <imp@FreeBSD.org>
 The port deskutils/calendar-data contains calendar files for the BSD calendar program and is maintained by se@.
 The data for this port lives in a link:https://github.com/freebsd/calendar-data[GitHub repository], which at the moment is maintained mainly by salvadore@.
 
-About two years ago, the calendar files in the base repository where removed from there and a new link:https://github.com/freebsd/calendar-data[repository] was created on GitHub; see also this link:https://reviews.freebsd.org/D26883[Phabricator review] about the creation of the associated port.
-This improvement allows calendar files to be updated indipendently from the base system.
+About two years ago, the calendar files in the base repository were removed from there and a new repository was created on GitHub; see also this link:https://reviews.freebsd.org/D26883[Phabricator review about the creation of the associated port].
+This improvement allows calendar files to be updated independently from the base system.
 
 Unfortunately, when the repository was created, it was forgotten to add a license to it.
 The issue has been solved this quarter with this link:https://github.com/freebsd/calendar-data/pull/9[pull request] submitted by salvadore@ and merged by imp@.


### PR DESCRIPTION
@se, @bsdimp: I am adding a report to our 2022q3 quarterly status report to inform all quarterly status reports readers about the license added to calendar-data. Please feel free to suggest improvements if you want.