### PR TITLE
core.adoc: grammar

### DIFF
--- a/2022q3/core.adoc
+++ b/2022q3/core.adoc
@@ -28,7 +28,7 @@ The Core Team unanimously votes to allow the memorial plaque for Bruce Evans men
 ===== EuroBSDCon core team office hour
 
 On Friday, September 16, the new Core Team presented at link:https://wiki.freebsd.org/DevSummit/202209[EuroBSDcon 2022 Developer Summit].
-The Core Team introduced themselves and talked a bit about our plans for this term.
+The Core Team introduced themselves and talked a bit about their plans for this term.
 There were discussions, Q & A, and suggestions from the attendees about the details.
 
 ==== Commit bits


### PR DESCRIPTION
themselves … our plans – should be: themselves … their plans

Or, just 'plans'.

