### PR TITLE
gcc.adoc: add a hard line break

### DIFF
--- a/2022q3/gcc.adoc
+++ b/2022q3/gcc.adoc
@@ -2,7 +2,7 @@
 
 Links: +
 link:https://gcc.gnu.org[GCC Project] URL: link:https://gcc.gnu.org[https://gcc.gnu.org] +
-link:https://gcc.gnu.org/gcc-11/[GCC 11 release series] URL: link:https://gcc.gnu.org/gcc-11/[https://gcc.gnu.org/gcc-11/]
+link:https://gcc.gnu.org/gcc-11/[GCC 11 release series] URL: link:https://gcc.gnu.org/gcc-11/[https://gcc.gnu.org/gcc-11/] +
 link:https://gcc.gnu.org/gcc-12/[GCC 12 release series] URL: link:https://gcc.gnu.org/gcc-12/[https://gcc.gnu.org/gcc-12/]
 
 Contact: <toolchain@FreeBSD.org> +


### PR DESCRIPTION
It appears that a hard line break is missing from the links section.