### PR TITLE
portmgr.adoc: corrections and suggestions

### DIFF
--- a/2022q3/portmgr.adoc
+++ b/2022q3/portmgr.adoc
@@ -48,7 +48,7 @@ The following happened under the hood:
 ** pkg 1.18.4
 ** Chromium 106.0.5249.91
 ** Firefox 105.0.1
-** Firefox ESR 102.3.0
+*** Firefox ESR 102.3.0
 ** KDE Applications 22.8.1
 ** KDE Frameworks 5.98
 ** Rust 1.63.0

--- a/2022q3/portmgr.adoc
+++ b/2022q3/portmgr.adoc
@@ -18,7 +18,7 @@ There are currently just under 2,800 open ports PRs of which 750 are unassigned.
 The last quarter saw 9,137 commits by 151 committers on the main branch and 589 commits by 61 committers on the 2022Q3 branch.
 Compared to two quarters ago, this means a slight increase in the number of ports, but also a slight increase in the number of (unassigned) ports PRs and a slight decrease in the number of commits made.
 
-In the last quarter, we welcomed Felix Palmen (zirias@) as a new ports committer, welcomed back Akonori MUSHA (knu@), and said goodbye to Olli Hauer (ohauer@).
+In the last quarter, we welcomed Felix Palmen (zirias@) as a new ports committer, welcomed back Akinori MUSHA (knu@), and said goodbye to Olli Hauer (ohauer@).
 We also welcomed Luca Pizzamiglio (pizzamig@) as an official member of portmgr.
 
 Some large changes in the Ports Tree were made during the last quarter:

--- a/2022q3/portmgr.adoc
+++ b/2022q3/portmgr.adoc
@@ -13,7 +13,8 @@ Contact: FreeBSD Ports Management Team <portmgr@FreeBSD.org>
 The Ports Management Team is responsible for overseeing the overall direction of the Ports Tree, building packages, and personnel matters.
 Below is what happened in the last quarter.
 
-Currently there are just over 30,500 ports in the Ports Tree. There are currently just under 2,800 open ports PRs of which 750 are unassigned.
+Currently there are just over 30,500 ports in the Ports Tree. 
+There are currently just under 2,800 open ports PRs of which 750 are unassigned.
 The last quarter saw 9,137 commits by 151 committers on the main branch and 589 commits by 61 committers on the 2022Q3 branch.
 Compared to two quarters ago, this means a slight increase in the number of ports, but also a slight increase in the number of (unassigned) ports PRs and a slight decrease in the number of commits made.
 
@@ -21,32 +22,35 @@ In the last quarter, we welcomed Felix Palmen (zirias@) as a new ports committer
 We also welcomed Luca Pizzamiglio (pizzamig@) as an official member of portmgr.
 
 Some large changes in the Ports Tree were made during the last quarter:
+
 * "Created by" lines have been removed from the top of each Makefile, as a lot of those were outdated.
 * WWW: has been moved from each pkg-descr into each Makefile as a variable; the below write-up is from Stefan Eßer (se@) who did the work:
+
 The description of a port's functionality should end with the URL of a web page that provides further information, such as best practices for usage or configuration. 
-This information can be displayed with "pkg query -e" for installed packages or "pkg rquery -e" for available packages. 
+This information can be displayed with `pkg query -e` for installed packages or `pkg rquery -e` for available packages. 
 The URL used to be appended to the end of the ports' pkg-descr files, with the prefix "WWW: ", so that tools could extract the URL from the description.
 Over time, many of these URLs have become stale, since port updates generally change only the Makefile, not the pkg-descr file.
 By moving the definition of these URLs into the Makefiles, maintainers are more likely to update the URL along with other port changes, and tools have easier access to them. 
-The URLs are now assigned to the WWW macro in the Makefile and can be queried with "make -V WWW" in the port directory.
-Tools that process the description contained in the package files still work because the "WWW:" lines at the end are generated from the WWW values in the Makefiles.
+The URLs are now assigned to the WWW macro in the Makefile and can be queried with `make -V WWW` in the port directory.
+Tools that process the description contained in the package files still work because the "WWW: " lines at the end are generated from the WWW values in the Makefiles.
 
-During EuroBSDCon, portmgr had a discussion about improving the situation for kernel module packages.
+During EuroBSDCon, portmgr@ had a discussion about improving the situation for kernel module packages.
 Various possibilities have been discussed.
 
 The following happened under the hood:
+
 * one new USES, "vala", was added.
 * The default version of Go got bumped to 1.19
 * CMake is now a meta-port
-* Initial support for Qt6 was added, at version 6.3.2
+* Initial support for Qt 6 was added, at version 6.3.2
 * Vim no longer installs a system-wide vimrc
 * A number of major ports got updated:
-  * pkg 1.18.4
-  * Chromium 106.0.5249.91
-  * Firefox 105.0.1
-  * Firefox-esr 102.3.0
-  * KDE Applications 22.8.1
-  * KDE Frameworks 5.98
-  * Rust 1.63.0
-  * SDL 2.24.0
-  * Xorg server 21.1.4 (overhaul)
+** pkg 1.18.4
+** Chromium 106.0.5249.91
+** Firefox 105.0.1
+** Firefox ESR 102.3.0
+** KDE Applications 22.8.1
+** KDE Frameworks 5.98
+** Rust 1.63.0
+** SDL 2.24.0
+** Xorg server 21.1.4 (overhaul)


### PR DESCRIPTION
Akinori (not Akonori) according to <https://people.freebsd.org/~knu/>. 

Correct markup for lists (<https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#lists> "… An empty line is required before and after a list to separate it from other blocks. …"); and for indented list items. 

Maybe better to use backticks, not ", to signify commands. 

Qt 6 is two words e.g. <https://www.qt.io/blog/qt-6.4-released>. Or, make it lowercase qt6, if it's as in devel/qt6.