### PR TITLE
pjdfstest.adoc: suggested changes

### DIFF
--- a/2022q3/pjdfstest.adoc
+++ b/2022q3/pjdfstest.adoc
@@ -1,27 +1,24 @@
-=== PJDFSTest rewrite 
+=== Rewrite of pjdfstest
 
 Links: +
 link:https://github.com/musikid/pjdfstest[Github] URL: link:https://github.com/musikid/pjdfstest[https://github.com/musikid/pjdfstest] +
 link:https://musikid.github.io/blog/rewrite-pjdfstest/[Blog] URL: https://musikid.github.io/blog/rewrite-pjdfstest/[https://musikid.github.io/blog/rewrite-pjdfstest/] +
 Contact: Alan Somers <asomers@FreeBSD.org>  
 
-Back in 2007, Pawel Jakub Dawidek <pjd@FreeBSD.org> wrote pjdfstest, a POSIX
-file system conformance test tool.  He originally wrote it to validate the port
-of ZFS to FreeBSD, but it's subsequently been used for other file systems and
-other operating systems, too.
+Back in 2007, Pawel Jakub Dawidek <pjd@FreeBSD.org> wrote pjdfstest, a POSIX file system conformance test tool.
+He originally wrote it to validate the port of ZFS to FreeBSD, but it has subsequently been used for other file systems and other operating systems.
 
-This year, Sayafdine Said <musikid@outlook.com> rewrote it under Google's sponsorship.  The new version has several improvements:
+This year, Sayafdine Said <musikid@outlook.com> rewrote it under Google's sponsorship.
+The new version has several improvements:
 
-* More configurable, so it better be used with other file systems.
+* More configurable, for better use with other file systems.
 * Much faster, largely thanks to said configurability.
 * Better test case isolation, making failure easy to debug.
 * No longer requires root privileges for all test cases.
 * Test cases can be run in a debugger.
 * More maintainable, less duplication.
 
-There are still a couple of lingering PRs to complete, but we expect to wrap
-those up and add pjdfstest to the ports collection soon.  From there it will be
-used both by /usr/tests for ZFS and UFS, and by external developers for other
-file systems.
+There are still a couple of lingering PRs to complete, but we expect to wrap those up and add pjdfstest to the ports collection soon.
+From there, it will be used both by `/usr/tests` for ZFS and UFS, and by external developers for other file systems.
 
 Sponsor: Google Summer of Code


### PR DESCRIPTION
Primarily (a nit), <http://markmail.org/message/ow6rqioptkanvlgi> re: the phrase "so it better be used with". Instead, maybe "for better use with"; or "for easier use with". 

Whilst here: 

* new lines (AsciiDoc)
* pjdfstest (lowercase) for consistency
* other minor improvements.