### PR TITLE
lsof.adoc: correction and suggestions

### DIFF
--- a/2022q3/lsof.adoc
+++ b/2022q3/lsof.adoc
@@ -1,12 +1,12 @@
 === sysutils/lsof major upgrade
 
 Link: +
-lsof project repo: <https://github.com/lsof-org/lsof>
+link:https://github.com/lsof-org/lsof[lsof project repo] URL: link:https://github.com/lsof-org/lsof[https://github.com/lsof-org/lsof]
 
 Contact: +
 Larry Rosenman <ler@FreeBSD.org>
 
-pacakge:sysutils/lsof[] had a major upgrade to no longer look in `/dev/kmem` for data, and to use the userland API.
+package:sysutils/lsof[] had a major upgrade to no longer look in `/dev/kmem` for data, and to use the userland API.
 This took a long time to hit the tree, but is finally done.
 It fixes man:lsof[8] to work with ZFS again for the first time since 13.0-RELEASE.
 

--- a/2022q3/lsof.adoc
+++ b/2022q3/lsof.adoc
@@ -1,22 +1,19 @@
 === sysutils/lsof major upgrade
 
-Links
-link:https://github.com/lsof-org/lsof[lsof project repo] URL: link:https://github.com/lsof-org/lsof[https://github.com/lsof-org/lsof] +
+Link: +
+lsof project repo: <https://github.com/lsof-org/lsof>
 
-Contact: Larry Rosenman <ler@FreeBSD.org>
+Contact: +
+Larry Rosenman <ler@FreeBSD.org>
 
-sysutils/lsof in ports has had a major upgrade to no longer go looking 
-in /dev/kmem for data and using the userland API.  This has taken a long
-time to hit the tree, but is finally done.  This fixes lsof(1) to work with
-ZFS again for the first time since 13.0-RELEASE.
+pacakge:sysutils/lsof[] had a major upgrade to no longer look in `/dev/kmem` for data, and to use the userland API.
+This took a long time to hit the tree, but is finally done.
+It fixes man:lsof[8] to work with ZFS again for the first time since 13.0-RELEASE.
 
-This will make the maintenance of sysutils/lsof much easier going forward.
+This will make maintenance much easier going forward.
 
-To the kernel folks: if you make changes that break lsof, please submit a 
-github PR to https://github.com/lsof-org/lsof. Please test any changes to
-the interfaces that lsof uses and make sure they still work.  These all should
-be userland interfaces now, but please test. 
+To the kernel folks: if you make changes that break lsof, please submit a GitHub pull request to https://github.com/lsof-org/lsof.
+Please test any changes to the interfaces that lsof uses and make sure they still work.
+These all should be userland interfaces now, but please test.
 
-My thanks to Warner Losh <imp@FreeBSD.org>, Mateusz Guzik <mjg@FreeBSD.org>,
-and Ed Maste <emaste@FreeBSD.org> for help getting this major change landed. 
-
+My thanks to Warner Losh <imp@FreeBSD.org>, Mateusz Guzik <mjg@FreeBSD.org>, and Ed Maste <emaste@FreeBSD.org> for help getting this major change landed. 


### PR DESCRIPTION
The manual page for lsof is in section 8, not section 1.

AsciiDoc: the + for a hard line break was superfluous, where the next line was blank.

<https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266881> aims to raise awareness of macros such as package and man.

Whilst the Link URL within this report is not part of a long sentence, the markup in this pull request might prove to be good in context of <https://github.com/freebsd/freebsd-quarterly/issues/530>.

Whilst here, a handful of suggested changes.