### PR TITLE
ufs_snapshots.adoc: intended indents

### DIFF
--- a/2022q3/ufs_snapshots.adoc
+++ b/2022q3/ufs_snapshots.adoc
@@ -5,35 +5,26 @@ link:https://reviews.freebsd.org/D36491[Milestone 1 Core Changes] URL: link:http
 
 Contact: Kirk McKusick <mckusick@FreeBSD.org>
 
-This project will make UFS/FFS filesystem snapshots avaiable when
-running with journaled soft updates.
+This project will make UFS/FFS filesystem snapshots avaiable when running with journaled soft updates.
 
-The UFS/FFS filesystem has the ability to take snapshots. Because
-the taking of snapshots was added after soft updates were written
-they were fully integrated with soft updates. When journaled soft
-updates were added in 2010, they were never integrated with
-snapshots. So snapshots cannot be used on filesystems running with
-journaled soft updates.
+The UFS/FFS filesystem has the ability to take snapshots.
+Because the taking of snapshots was added after soft updates were written they were fully integrated with soft updates.
+When journaled soft updates were added in 2010, they were never integrated with snapshots.
+So snapshots cannot be used on filesystems running with journaled soft updates.
 
-Snapshots became less important with the support for ZFS on FreeBSD
-since ZFS can take snapshots quickly and easily. However there
-remain two instances where UFS snapshots are still important. The
-first is that they allow reliable dumps of live filesystems which
-avoids possibly hours of down time. The second is that they allow
-the running of background fsck. Similar to the need for scrub in
-ZFS, fsck needs to be run periodically to find undetected disk
-failures. Snapshots allow fsck to be run on live filesystems rather
-than needing to schedule down time to run it.
+Snapshots became less important with the support for ZFS on FreeBSD since ZFS can take snapshots quickly and easily.
+However there remain two instances where UFS snapshots are still important.
+The first is that they allow reliable dumps of live filesystems which avoids possibly hours of down time.
+The second is that they allow the running of background fsck.
+Similar to the need for scrub in ZFS, fsck needs to be run periodically to find undetected disk failures.
+Snapshots allow fsck to be run on live filesystems rather than needing to schedule down time to run it.
 
 This project has two milestones:
 
-Milestone 1: enable snapshots when running with journaled soft
-  updates and ensure that they can be used for doing background
-  dumps on a live filesystem. This milestone should be completed
-  by the end of 2022.
+1. enable snapshots when running with journaled soft updates and ensure that they can be used for doing background dumps on a live filesystem.
+This milestone should be completed by the end of 2022.
 
-Milestone 2: extend fsck_ffs to be able to do a background check
-  using a snapshot on a filesystem running with journaled soft
-  updates. This milestone is expected by Q3 of 2023.
+2. extend fsck_ffs to be able to do a background check using a snapshot on a filesystem running with journaled soft updates.
+This milestone is expected by Q3 of 2023.
 
 Sponsored by: The FreeBSD Foundation


### PR DESCRIPTION
Respect the author's intention for each of the two milestone paragraphs to be indented (compare with the raw text of the original – screenshot below). 

Whilst here: AsciiDoc line breaks.

----

![image](https://user-images.githubusercontent.com/192271/195798424-25deba7d-4699-4462-b560-9686c34b1c90.png)