### PR TITLE
intro.adoc: suggested changes

### DIFF
--- a/2022q3/intro.adoc
+++ b/2022q3/intro.adoc
@@ -1,11 +1,11 @@
-Here is the third quarterly report for year 2022, with 24 reports included, which is slightly fewer than last quarter.
+Here is the third quarterly report for year 2022, with 24 reports included, which is slightly fewer than link:https://www.freebsd.org/status/report-2022-04-2022-06/[last quarter].
 
 I notice that in the past we had quarters with many more reports: often more than 30, sometimes even more than 40.
 Thus I would like to encourage all of you to submit reports: reports are useful to share your work, to find help, to have more eyes reviewing your changes, to have more people testing your software, to reach a wider audience whenever you need to tell something to all of the FreeBSD community and in many other cases.
-Please do not be shy and do not worry if you are not a native English speaker or if you are not proficient in AsciiDoc syntax: the quarterly team will be glad to help you in whatever you need.
+Please do not be shy, and do not worry if you are not a native English speaker or if you are not proficient in AsciiDoc syntax: the team will be glad to help you in whatever you need.
 
-On the other hand, if you really do not have anything to report, then maybe you might like to join one of the interesting projects described below, or you might be inspired from one of them to do something new, thus having something to report in the future.
+If you really have nothing to report, then you might like to join one of the interesting projects described below, or be inspired by one of them to do something new, thus having something to report in the future.
 
 We wish you all a pleasant read.
 
-Lorenzo Salvadore, on behalf of the status report team.
+Lorenzo Salvadore, on behalf of the link:https://www.freebsd.org/status/[status report] team.


### PR DESCRIPTION
Late changes, so feel to reject all suggestions. 

This pull request dovetails with the conversation at <https://github.com/freebsd/freebsd-quarterly/pull/535#pullrequestreview-1143200832> about possible methods of contacting the team, or individual members. 

Link to the main FreeBSD Status Reports page, which is not directly available through the current sidebar (it's indirectly through the News link). 

Whilst here: maybe also link to last quarter's report. 

Without something (first) 'on one hand', there should be nothing 'on the other hand'. 

Avoid combining 'maybe' with 'might'. 

The phrase 'quarterly team' is a little ambiguous. Better: 'status report team' (or 'quarterly status report team') in the sign-off.