### PR TITLE
GCC: paragraphs, and some changes to wording

### DIFF
--- a/2022q4/gcc.adoc
+++ b/2022q4/gcc.adoc
@@ -1,4 +1,4 @@
-=== GCC: Update GCC default version to version 12
+=== GCC
 
 Links: +
 link:https://gcc.gnu.org[GCC Project] URL: link:https://gcc.gnu.org[https://gcc.gnu.org] +
@@ -7,19 +7,44 @@ link:https://gcc.gnu.org/gcc-12/[GCC 12 release series] URL: link:https://gcc.gn
 
 Contact: Lorenzo Salvadore <salvadore@FreeBSD.org> +
 
- * The GCC default version has now been updated to version 12.
-   Thank you very much to antoine@ for running the necessary exp-runs and to all the contributors, maintainers and committers involved in the process.
-   As it has been noted last quarter, for every major version of GCC FreeBSD usually waits for the release of the second minor version to update GCC default version. However next time I would like to attempt to update the default version as soon as the first minor version of GCC 13 is out. The rationale for waiting the second minor release is to wait for other operating systems (in particular Linux distributions) to find the bugs, report them, and fix them, so that FreeBSD could focus mainly on FreeBSD specific cases. But this also means that upstream software developers only hear from FreeBSD rarely and mostly when it concerns FreeBSD only, thus our operating system risks being considered minor and unimportant for them.
-   My hope is that software authors can value supporting FreeBSD more as the number of its contributions to other projects also increases. Of course I understand that this will imply more work for all ports maintainers and I will do my best to help them as much as I can.
-   link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265948[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=2659548]
+==== Update GCC default version to 12
+ 
+Thank you very much to antoine@ for running the necessary exp-runs and to all the contributors, maintainers and committers involved in the process.
 
- * A conflict preventing the installation of multiple versions of GCC has been solved, so now lang/gcc11 and lang/gcc12 can be installed at the same time. This was particularly important for the update of the GCC default version, since a few ports have been kept to compile with GCC 11 for now.
-   Note however that at the moment only one -devel GCC port at the time can be installed on your system. This is because I have patched the standard ports only: for the -devel port I expect upstream to fix the issue soon, by using a link:https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101491[patch submitted by a FreeBSD user] or link:https://gcc.gnu.org/pipermail/gcc-patches/2022-November/606450.html[my own patch], or using some other solution.
-   link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257060[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257060]
+As was noted last quarter, for every major version of GCC, FreeBSD usually awaits the release of the second minor version to update GCC default version.
+However next time I would like to attempt to update the default version as soon as the first minor version of GCC 13 is out.
+The rationale for awaiting the second minor release was to wait for other operating systems (in particular Linux distributions) to find, report, and fix bugs, so that FreeBSD could focus mainly on FreeBSD-specific cases.
+But this also meant that upstream software developers only heard from FreeBSD rarely, and mostly when it concerned FreeBSD only, thus our operating system risks being considered minor and unimportant for them.
 
- * The D language has been enabled in lang/gcc11 and lang/gcc11-devel thanks to diizzy. I plan to include D support for higher versions of GCC too, but this cannot be done as easily as for GCC 11 due to bootstrapping issues: starting from GCC 12, the D compiler GDC needs a working GDC to be built.
-   link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266825[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266825]
+My hope is that software authors can value supporting FreeBSD more as the number of its contributions to other projects also increases.
+Of course I understand that this will imply more work for all ports maintainers and I will do my best to help them as much as I can.
 
- * Software compiled with GCC using the -fsanitize=address switch has been reported to crash. I have fixed the issue for lang/gcc11, lang/gcc11-devel, lang/gcc12, and lang/gcc12-devel. I am still working on lang/gcc13-devel.
-   Use of the address sanitizer requires ASLR to be disabled. As GCC gets the code that I am modifying from LLVM, and LLVM is also included in the FreeBSD src repository with some patches that improve ASLR detection and automatically re-run programs with ASLR disabled when necessary, I am also merging those patches.
-   link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267751[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267751]
+link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265948[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=2659548]
+
+==== Multiple versions
+ 
+A conflict preventing the installation of multiple versions of GCC was resolved. Now, lang/gcc11 and lang/gcc12 can be installed at the same time.
+This was particularly important for the update of the GCC default version, since a few ports have been kept to compile with GCC 11 for now.
+
+Note however that at the moment only one -devel GCC port at the time can be installed on your system.
+This is because I have patched the standard ports only: for the -devel port I expect upstream to fix the issue soon, by using a link:https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101491[patch submitted by a FreeBSD user] or link:https://gcc.gnu.org/pipermail/gcc-patches/2022-November/606450.html[my own patch], or using some other solution.
+
+link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257060[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257060]
+
+==== D language
+
+D is now enabled in lang/gcc11 and lang/gcc11-devel, thanks to diizzy.
+I plan to include D support for higher versions of GCC too, but this cannot be done as easily as for GCC 11 due to bootstrapping issues: starting from GCC 12, the D compiler GDC needs a working GDC to be built.
+
+link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266825[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266825]
+
+==== Crashes with -fsanitize=address
+
+Software compiled with GCC using the `-fsanitize=address` switch has been reported to crash.
+I have fixed the issue for lang/gcc11, lang/gcc11-devel, lang/gcc12, and lang/gcc12-devel.
+I am still working on lang/gcc13-devel.
+
+Use of the address sanitizer requires ASLR to be disabled.
+As GCC gets the code that I am modifying from LLVM, and LLVM is also included in the FreeBSD src repository with some patches that improve ASLR detection and automatically re-run programs with ASLR disabled when necessary, I am also merging those patches.
+
+link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267751[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267751]

--- a/2022q4/gcc.adoc
+++ b/2022q4/gcc.adoc
@@ -21,9 +21,9 @@ Of course I understand that this will imply more work for all ports maintainers 
 
 link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265948[https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=2659548]
 
-==== Multiple versions
+==== Resolution of a conflict preventing the installation of multiple GCC versions simultaneously
  
-A conflict preventing the installation of multiple versions of GCC was resolved. Now, lang/gcc11 and lang/gcc12 can be installed at the same time.
+Now, lang/gcc11 and lang/gcc12 can be installed at the same time.
 This was particularly important for the update of the GCC default version, since a few ports have been kept to compile with GCC 11 for now.
 
 Note however that at the moment only one -devel GCC port at the time can be installed on your system.


### PR DESCRIPTION
<https://github.com/freebsd/freebsd-quarterly/pull/558#discussion_r1060159833> "… my intention was to create separate paragraphs …". 

For this to work, it seems that we must either: 

* introduce custom styling (see, for example, <https://stackoverflow.com/a/64231996/38108>); or

* more simply, use paragraphs without customisation – and not attempt to indent.

So, for simplicity here: 

* subheadings in lieu of bullet points

* paragraphs below subheadings.

To allow fairly concise subheadings: I made the first heading generic, then adjusted each new subheading and subsequent words. 

----

Plus, whilst proofing, a few other suggested changes. 

@lsalvadore please, how is this?