### PR TITLE
Foundation, 2022q3: fix indented paragraphs

### DIFF
--- a/2022q3/freebsd-foundation.adoc
+++ b/2022q3/freebsd-foundation.adoc
@@ -10,50 +10,34 @@ link:https://www.FreeBSDfoundation.org/news-and-events/[Foundation News and Even
 
 Contact: Deb Goodkin <deb@FreeBSDFoundation.org>
 
-The FreeBSD Foundation is a 501(c)(3) non-profit organization dedicated to
-supporting and promoting the FreeBSD Project and community worldwide.  Donations
-from individuals and corporations are used to fund and manage software
-development projects, conferences, and developer summits.  We also provide
-travel grants to FreeBSD contributors, purchase and support hardware to improve
-and maintain FreeBSD infrastructure, and provide resources to improve security,
-quality assurance, and release engineering efforts.  We publish marketing
-material to promote, educate, and advocate for the FreeBSD Project, facilitate
-collaboration between commercial vendors and FreeBSD developers, and finally,
-represent the FreeBSD Project in executing contracts, license agreements, and
-other legal arrangements that require a recognized legal entity.
+The FreeBSD Foundation is a 501(c)(3) non-profit organization dedicated to supporting and promoting the FreeBSD Project and community worldwide.
+Donations from individuals and corporations are used to fund and manage software development projects, conferences, and developer summits.
+We also provide travel grants to FreeBSD contributors, purchase and support hardware to improve and maintain FreeBSD infrastructure, and provide resources to improve security, quality assurance, and release engineering efforts.
+We publish marketing material to promote, educate, and advocate for the FreeBSD Project, facilitate collaboration between commercial vendors and FreeBSD developers, and finally, represent the FreeBSD Project in executing contracts, license agreements, and other legal arrangements that require a recognized legal entity.
 
 ==== Fundraising Efforts
 
-First, I’d like to send a big thank you to everyone who gave a financial
-contribution to our efforts.  We are 100% funded by your donations, so every
-contribution helps us continue to support FreeBSD in many ways, including some
-of the work funded and published in this status report.
+First, I’d like to send a big thank you to everyone who gave a financial contribution to our efforts.
+We are 100% funded by your donations, so every contribution helps us continue to support FreeBSD in many ways, including some of the work funded and published in this status report.
 
-We support FreeBSD in five main areas. Software development is the largest area
-we fund through staff developers and contractors who implement new features,
-support tier 1 platforms, review patches, and fix issues.  You can read about
-some of the work we did under OS Improvements in this report.  FreeBSD Advocacy
-is another area that we support to spread the word about FreeBSD at conferences,
-in presentations online and in-person, and through tutorials and how-to guides.
-We purchase and support hardware for the FreeBSD infrastructure that supports
-the work going on in the Project.  Virtual and in-person events are organized by
-the Foundation to help connect and engage community members to share their
-knowledge and collaborate on projects.  Finally, we provide legal support to the
-Project when needed and protect the FreeBSD trademarks.
+We support FreeBSD in five main areas.
+Software development is the largest area we fund through staff developers and contractors who implement new features, support tier 1 platforms, review patches, and fix issues.
+You can read about some of the work we did under OS Improvements in this report.
+FreeBSD Advocacy is another area that we support to spread the word about FreeBSD at conferences, in presentations online and in-person, and through tutorials and how-to guides.
+We purchase and support hardware for the FreeBSD infrastructure that supports the work going on in the Project.
+Virtual and in-person events are organized by the Foundation to help connect and engage community members to share their knowledge and collaborate on projects.
+Finally, we provide legal support to the Project when needed and protect the FreeBSD trademarks.
 
-Our goal this year is to raise at a minimum $1,400,000 towards a spending budget
-of around $2,000,000.  As we enter the last quarter of 2022, our donation total
-sits at $167,348, so we still need your help.  If you haven't made a donation
-this year, please consider making one at https://freebsdfoundation.org/donate/.
-We also have a Partnership Program for larger commercial donors.  You can find
-out more at
-https://freebsdfoundation.org/our-donors/freebsd-foundation-partnership-program/
+Our goal this year is to raise at a minimum $1,400,000 towards a spending budget of around $2,000,000.
+As we enter the last quarter of 2022, our donation total sits at $167,348, so we still need your help.
+If you haven't made a donation this year, please consider making one at https://freebsdfoundation.org/donate/.
+We also have a Partnership Program for larger commercial donors.
+You can find out more at https://freebsdfoundation.org/our-donors/freebsd-foundation-partnership-program/
 
 ==== OS Improvements
 
-During the third quarter of 2022, 300 src, 36 ports, and 13 doc tree commits
-were made that identified The FreeBSD Foundation as a sponsor.  Some of that
-work has dedicated report entries.
+During the third quarter of 2022, 300 src, 36 ports, and 13 doc tree commits were made that identified The FreeBSD Foundation as a sponsor.
+Some of that work has dedicated report entries.
 
 * FreeBSD as a Tier I cloud-init Platform
 * Intel wireless towards 11ac
@@ -61,47 +45,30 @@ work has dedicated report entries.
 * OpenStack on FreeBSD
 * Snapshots on Filesystems Using Journaled Soft Updates
 
-The other sponsored work is challenging to concisely summarize.  It varies from
-complex new features to various bug fixes spanning the src tree.  Here is a
-small sample to give a flavor of last quarter's work.
+The other sponsored work is challenging to concisely summarize.
+It varies from complex new features to various bug fixes spanning the src tree.
+Here is a small sample to give a flavor of last quarter's work.
 
-- 240afd8 makefs: Add ZFS support
+- 240afd8 makefs: Add ZFS support +
++
+This allows one to take a staged directory tree and create a file consisting of a ZFS pool with one or more datasets that contain the contents of the directory tree. This is useful for creating virtual machine images without using the kernel to create a pool; `zpool create` requires root privileges and currently is not permitted in jails. `makefs -t zfs` also provides reproducible images by using a fixed seed for pseudo-random number generation, used for generating GUIDs and hash salts. `makefs -t zfs` requires relatively little by way of machine resources.
 
-  This allows one to take a staged directory tree and create a file consisting
-  of a ZFS pool with one or more datasets that contain the contents of the
-  directory tree.  This is useful for creating virtual machine images without
-  using the kernel to create a pool; "zpool create" requires root privileges and
-  currently is not permitted in jails.  makefs -t zfs also provides reproducible
-  images by using a fixed seed for pseudo-random number generation, used for
-  generating GUIDs and hash salts.  makefs -t zfs requires relatively little by
-  way of machine resources.
+-  36f1526 Add experimental 16k page support on arm64 +
++
+Add initial 16k page support on arm64. It is considered experimental, with no guarantee of compatibility with userspace or kernel modules built with the current 4k page size. Testing has shown good results in kernel workloads that allocate and free large amounts of memory as only a quarter of the number of calls into the VM subsystem are needed in the best case.
 
--  36f1526 Add experimental 16k page support on arm64
+- 1424f65 vm_pager: Remove the default pager +
++
+It's unused now. Keep the `OBJ_DEFAULT` identifier, but make it an alias of `OBJT_SWAP` for the benefit of out-of-tree code.
 
-   Add initial 16k page support on arm64. It is considered experimental, with no
-   guarantee of compatibility with userspace or kernel modules built with the
-   current 4k page size. Testing has shown good results in kernel workloads that
-   allocate and free large amounts of memory as only a quarter of the number of
-   calls into the VM subsystem are needed in the best case.
-
-- 1424f65 vm_pager: Remove the default pager
-
-  It's unused now.  Keep the OBJ_DEFAULT identifier, but make it an alias of
-  OBJT_SWAP for the benefit of out-of-tree code.
-
-- a889a65 eventtimer: Fix several races in the timer reload code
-
-  In handleevents(), lock the timer state before fetching the time for the next
-  event.  A concurrent callout_cc_add() call might be changing the next event
-  time, and the race can cause handleevents() to program an out-of-date time,
-  causing the callout to run later (by an unbounded period, up to the idle
-  hardclock period of 1s) than requested.
+- a889a65 eventtimer: Fix several races in the timer reload code +
++
+In `handleevents()`, lock the timer state before fetching the time for the next event. A concurrent `callout_cc_add()` call might be changing the next event time, and the race can cause `handleevents()` to program an out-of-date time, causing the callout to run later (by an unbounded period, up to the idle hardclock period of 1s) than requested.
 
 ===== Bhyve Issue Support
 
-The Foundation contracted John Baldwin to dedicate time to Bhyve as issues
-arise, especially security issues.  Here is a summary of his 2022q3 work on that
-contract.
+The Foundation contracted John Baldwin to dedicate time to Bhyve as issues arise, especially security issues.
+Here is a summary of his 2022q3 work on that contract.
 
 - bb31aee bhyve virtio-scsi: Avoid out of bounds accesses to guest requests.
 - 62806a7 bhyve virtio-scsi: Tidy warning and debug prints.
@@ -114,65 +81,41 @@ contract.
 
 ===== RISC-V Improvements
 
-At the end of the quarter, the Foundation contracted Mitchell Horne to add and
-improve support for RISC-V hardware.  Mitchell will also perform general
-maintenance such as fixing bugs, handling reports, providing review for new code
-changes, and improving source code legibility and documentation.
+At the end of the quarter, the Foundation contracted Mitchell Horne to add and improve support for RISC-V hardware.
+Mitchell will also perform general maintenance such as fixing bugs, handling reports, providing review for new code changes, and improving source code legibility and documentation.
 
 ==== Continuous Integration and Quality Assurance
 
-The Foundation provides a full-time staff member and funds projects to improve
-continuous integration, automated testing, and overall quality assurance efforts
-for the FreeBSD project.  You can read about CI activities this quarter in a
-dedicated entry.
+The Foundation provides a full-time staff member and funds projects to improve continuous integration, automated testing, and overall quality assurance efforts for the FreeBSD project.
+You can read about CI activities this quarter in a dedicated entry.
 
 ==== FreeBSD Advocacy and Education
 
-Much of our effort is dedicated to Project advocacy.  This may involve
-highlighting interesting FreeBSD work, producing literature and video tutorials,
-attending events, or giving presentations.  The goal of the literature we
-produce is to teach people FreeBSD basics and help make their path to adoption
-or contribution easier.  Other than attending and presenting at events, we
-encourage and help community members run their own FreeBSD events, give
-presentations, or staff FreeBSD tables.
+Much of our effort is dedicated to Project advocacy.
+This may involve highlighting interesting FreeBSD work, producing literature and video tutorials, attending events, or giving presentations.
+The goal of the literature we produce is to teach people FreeBSD basics and help make their path to adoption or contribution easier.
+Other than attending and presenting at events, we encourage and help community members run their own FreeBSD events, give presentations, or staff FreeBSD tables.
 
-The FreeBSD Foundation sponsors many conferences, events, and summits around the
-globe.  These events can be BSD-related, open source, or technology events
-geared towards underrepresented groups.  We support the FreeBSD-focused events
-to help provide a venue for sharing knowledge, working together on projects, and
-facilitating collaboration between developers and commercial users.  This all
-helps provide a healthy ecosystem.  We support the non-FreeBSD events to promote
-and raise awareness of FreeBSD, to increase the use of FreeBSD in different
-applications, and to recruit more contributors to the Project. We are continuing
-to attend events both in person and virtual as well as planning the November
-Vendor Summit. In addition to attending and planning virtual events, we are
-continually working on new training initiatives and updating our selection of
-link:https://freebsdfoundation.org/freebsd-project/resources/[how-to guides] to
-facilitate getting more folks to try out FreeBSD.
+The FreeBSD Foundation sponsors many conferences, events, and summits around the globe.
+These events can be BSD-related, open source, or technology events geared towards underrepresented groups.
+We support the FreeBSD-focused events to help provide a venue for sharing knowledge, working together on projects, and facilitating collaboration between developers and commercial users.
+This all helps provide a healthy ecosystem.
+We support the non-FreeBSD events to promote and raise awareness of FreeBSD, to increase the use of FreeBSD in different applications, and to recruit more contributors to the Project.
+We are continuing to attend events both in person and virtual as well as planning the November Vendor Summit.
+In addition to attending and planning virtual events, we are continually working on new training initiatives and updating our selection of link:https://freebsdfoundation.org/freebsd-project/resources/[how-to guides] to facilitate getting more folks to try out FreeBSD.
 
 Check out some of the advocacy and education work we did last quarter:
 
-* Held a FreeBSD Workshop and Staffed a booth at Scale 19x in Los Angeles, CA on
-  July 28-30. You can read more about our participation in the
-  link:https://freebsdfoundation.org/blog/scale19x-conference-report/[SCALE19X
-  Conference Report]
+* Held a FreeBSD Workshop and Staffed a booth at Scale 19x in Los Angeles, CA on July 28-30.
+You can read more about our participation in the link:https://freebsdfoundation.org/blog/scale19x-conference-report/[SCALE19X Conference Report]
 * Sponsored and attended link:https://coscup.org/2022/en/[COSCUP], July 30-31, Taiwan
-* Attended the EuroBSDCon Developer Summit and sponsored and attended
-  link:https://2022.eurobsdcon.org/[EuroBSDcon 2022], September 15-18, Vienna,
-  Austria
-* link:http://toilers.mines.edu/RMCWiC/2022/home.html[Sponsored and Presented at the Rocky Mountain Celebration of Women in
-  Computing], September 29-30, 2022. Slides from Deb’s presentation can be found
-  link:http://toilers.mines.edu/RMCWiC/2022/program.html[here].
-* Published the
-  link:https://freebsdfoundation.org/news-and-events/newsletter/freebsd-foundation-summer-2022-update/[FreeBSD
-  Foundation Summer 2022 Update]
-* Continued our participation in Google Summer of Code as both an admin and
-  mentors. Interviews with some of the Google Summer of Code Students can be
-  found link:https://freebsdfoundation.org/our-work/latest-updates/[here].
-* Introduced a new
-  link:https://freebsdfoundation.org/freebsd-project/resources/[FreeBSD
-  Resources] page that allows for search by type of subject, type of content and
-  difficulty level.
+* Attended the EuroBSDCon Developer Summit and sponsored and attended link:https://2022.eurobsdcon.org/[EuroBSDcon 2022], September 15-18, Vienna, Austria
+* link:http://toilers.mines.edu/RMCWiC/2022/home.html[Sponsored and Presented at the Rocky Mountain Celebration of Women in Computing], September 29-30, 2022.
+Slides from Deb’s presentation can be found link:http://toilers.mines.edu/RMCWiC/2022/program.html[here].
+* Published the link:https://freebsdfoundation.org/news-and-events/newsletter/freebsd-foundation-summer-2022-update/[FreeBSD Foundation Summer 2022 Update]
+* Continued our participation in Google Summer of Code as both an admin and mentors.
+Interviews with some of the Google Summer of Code Students can be found link:https://freebsdfoundation.org/our-work/latest-updates/[here].
+* Introduced a new link:https://freebsdfoundation.org/freebsd-project/resources/[FreeBSD Resources] page that allows for search by type of subject, type of content and difficulty level.
 * New Blog Posts:
 
 ** Guest Post: link:https://freebsdfoundation.org/blog/guest-post-freebsd-in-science/[FreeBSD in Science]
@@ -183,19 +126,15 @@ Check out some of the advocacy and education work we did last quarter:
 ** link:https://freebsdfoundation.org/blog/new-freebsd-quick-guide-video-playback-on-freebsd-quick-guide/[FreeBSD Quick Guide: Video Playback on FreeBSD]
 ** link:https://freebsdfoundation.org/resource/binary-package-management-on-freebsd/[Binary Package Management on FreeBSD]
 
-We help educate the world about FreeBSD by publishing the professionally
-produced FreeBSD Journal.  As we mentioned previously, the FreeBSD Journal is
-now a free publication.  Find out more and access the latest issues at
-link:https://www.FreeBSDfoundation.org/journal/[https://www.FreeBSDfoundation.org/journal/].
+We help educate the world about FreeBSD by publishing the professionally produced FreeBSD Journal.
+As we mentioned previously, the FreeBSD Journal is now a free publication.
+Find out more and access the latest issues at link:https://www.FreeBSDfoundation.org/journal/[https://www.FreeBSDfoundation.org/journal/].
 
-You can find out more about events we attended and upcoming events at
-link:https://www.FreeBSDfoundation.org/news-and-events/[https://www.FreeBSDfoundation.org/news-and-events/].
+You can find out more about events we attended and upcoming events at link:https://www.FreeBSDfoundation.org/news-and-events/[https://www.FreeBSDfoundation.org/news-and-events/].
 
 ==== Legal/FreeBSD IP
 
-The Foundation owns the FreeBSD trademarks, and it is our responsibility to
-protect them.  We also provide legal support for the core team to investigate
-questions that arise.
+The Foundation owns the FreeBSD trademarks, and it is our responsibility to protect them.
+We also provide legal support for the core team to investigate questions that arise.
 
-Go to link:https://www.FreeBSDfoundation.org[https://www.FreeBSDFoundation.org]
-to find more about how we support FreeBSD and how we can help you!
+Go to link:https://www.FreeBSDfoundation.org[https://www.FreeBSDFoundation.org] to find more about how we support FreeBSD and how we can help you!


### PR DESCRIPTION
I became curious after yesterday's <https://github.com/freebsd/freebsd-quarterly/pull/563#issue-1516664907>, because I did have a vague recollection of successfully indenting paragraphs a few months ago – without the unwanted side effects that are seen under <https://web.archive.org/web/20221030173557/https://www.freebsd.org/status/report-2022-07-2022-09/#_os_improvements>: 

* monospace
* fixed-width paragraphs.

Whilst a change to a report from a previous quarter is extraordinary, merging this might prove the usefulness of hard line breaks <https://docs.asciidoctor.org/asciidoc/latest/blocks/hard-line-breaks/>. (It appears OK in GitHub, need to check that a www.freebsd.org end result also appears OK.)