### PR TITLE
FreshPorts: corrections and suggestions

### DIFF
--- a/2022q4/FreshPorts.adoc
+++ b/2022q4/FreshPorts.adoc
@@ -4,7 +4,7 @@ Links: +
 https://freshports.org/[FreshPorts] URL: https://freshports.org/[https://freshports.org/] +
 https://news.freshports.org/[FreshPorts blog] URL: https://news.freshports.org/[https://news.freshports.org/]
 
-Contact: Dan Langille <dan@FreeBSD.org>  
+Contact: Dan Langille <dvl@FreeBSD.org>  
 
 FreshPorts and FreshSource have reported upon FreeBSD commits for 20 years.
 They cover all commits, not just ports.

--- a/2022q4/FreshPorts.adoc
+++ b/2022q4/FreshPorts.adoc
@@ -1,8 +1,8 @@
 ## FreshPorts - help wanted ##
 
 Links: +
-https://freshports.org/[FreshPorts] URL: https://freshports.org/[https://freshports.org/] +
-https://news.freshports.org/[FreshPorts blog] URL: https://news.freshports.org/[https://news.freshports.org/]
+link:https://freshports.org/[FreshPorts] URL: link:https://freshports.org/[https://freshports.org/] +
+link:https://news.freshports.org/[FreshPorts blog] URL: link:https://news.freshports.org/[https://news.freshports.org/]
 
 Contact: Dan Langille <dvl@FreeBSD.org>  
 
@@ -11,7 +11,7 @@ They cover all commits, not just ports.
 
 FreshPorts tracks the commits and extracts data from the port Makefiles to create a database of information useful to both port maintainers and port users.
 
-For example, https://www.freshports.org/security/acme.sh/[https://www.freshports.org/security/acme.sh/] shows the history of the _acme.sh_ port, back to its creation in May 2017.
+For example, link:https://www.freshports.org/security/acme.sh/[https://www.freshports.org/security/acme.sh/] shows the history of the _acme.sh_ port, back to its creation in May 2017.
 
 ### Converting the backend repository ###
 
@@ -22,7 +22,7 @@ I have wanted to convert these repositories to Git for some time.
 
 I would like help with this please.
 I'll give you a copy of the repositories and you give me back several Git repos (one for each).
-They will be uploaded to https://github.com/FreshPorts[https://github.com/FreshPorts] (our project on GitHub).
+They will be uploaded to link:https://github.com/FreshPorts[https://github.com/FreshPorts] (our project on GitHub).
 
 These are the existing Subversion repos:
 

--- a/2022q4/FreshPorts.adoc
+++ b/2022q4/FreshPorts.adoc
@@ -1,7 +1,8 @@
 ## FreshPorts - help wanted ##
 
-Link:	 https://freshports.org/[FreshPorts]
-Link:	 https://news.freshports.org/[FreshPorts blog]
+Links: +
+https://freshports.org/[FreshPorts] URL: https://freshports.org/[https://freshports.org/] +
+https://news.freshports.org/[FreshPorts blog] URL: https://news.freshports.org/[https://news.freshports.org/]
 
 Contact: Dan Langille <dan@FreeBSD.org>  
 
@@ -10,27 +11,27 @@ They cover all commits, not just ports.
 
 FreshPorts tracks the commits and extracts data from the port Makefiles to create a database of information useful to both port maintainers and port users.
 
-For example, link:https://www.freshports.org/security/acme.sh/[https://www.freshports.org/security/acme.sh/] shows the history of this port, back to its creation in May 2017.
+For example, https://www.freshports.org/security/acme.sh/[https://www.freshports.org/security/acme.sh/] shows the history of the _acme.sh_ port, back to its creation in May 2017.
 
 ### Converting the backend repository ###
 
 This topic deals with the FreshPorts code repository.
-The front end (website) was converted from subversion to git several years ago.
-The back end, which processes FreeBSD commits and updates the database, is still on subversion.
-I have wanted to convert these repositories to git for some time.
+The front end (website) was converted from Subversion to Git several years ago.
+The back end, which processes FreeBSD commits and updates the database, is still on Subversion.
+I have wanted to convert these repositories to Git for some time.
 
 I would like help with this please.
-I'll give you a copy of the repositories and you give me back several git repos (one for each).
-They will be uploaded to link:https://github.com/FreshPorts[https://github.com/FreshPorts] (our project on GitHub).
+I'll give you a copy of the repositories and you give me back several Git repos (one for each).
+They will be uploaded to https://github.com/FreshPorts[https://github.com/FreshPorts] (our project on GitHub).
 
-These are the existing subversion repos:
+These are the existing Subversion repos:
 
 * ingress (code for the back end)
 * database schema
 * backend - monitoring code
-* packaging - scripts for cutting new tarballs - deprecated via git
-* daemontools - now misnamed, because the scripts use daemon(8)
-* periodics - scripts started by periodic(8)
+* packaging - scripts for cutting new tarballs - deprecated via Git
+* daemontools - now misnamed, because the scripts use man:daemon[8]
+* periodics - scripts started by man:periodic[8]
 * ports - for the FreeBSD packages which install the above.
 
 ### I won't be running FreshPorts forever ###
@@ -41,7 +42,7 @@ There are several aspects to FreshPorts:
 
 * FreeBSD admin (updating the OS and packages)
 * front end code (website - mostly PHP)
-* back end code (commit processing - perl, python, shell)
+* back end code (commit processing - Perl, Python, shell)
 * database design (PostgreSQL).
 
 The database does not change very often and requires little maintenance compared to the applications and OS.


### PR DESCRIPTION
For two different URLs at the head of a contributed report, workflow requires three separate lines (with two hard line breaks), as shown at: 

https://raw.githubusercontent.com/freebsd/freebsd-quarterly/master/report-sample.adoc

– if I recall correctly, this requirement relates to production of the email version of the collated report. 

In parallel, from the important note at <https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#links>: 

> The link: macro prefix is not required when the target starts with a URL scheme like https:. …

– we might update the report-sample file in due course. 

Whilst here: 

* macro for manual pages (ref: <https://bugs.freebsd.org/266881#c1>)
* uppercase G for Git, when not a command (ref: <https://git-scm.com/>)
* uppercase P for Perl and for Python
* uppercase S for Subversion
* have acme.sh named.