### PR TITLE
NFS in prisons: correction and suggestions

### DIFF
--- a/2022q4/NFS-in-prisons.adoc
+++ b/2022q4/NFS-in-prisons.adoc
@@ -1,14 +1,14 @@
 === Enable the NFS server to run in a vnet prison
 
 Links: +
-https://people.freebsd.org/~rmacklem/vnet.patch[Source patch for main] URL: https://people.freebsd.org/~rmacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
-https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
+https://people.freebsd.org/~rmacklem/vnet.patch[Source patch for main] URL: link:https://people.freebsd.org/~rmacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
+https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: link:https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
 
 Contact: Rick Macklem <rmacklem@freebsd.org>
 
 Several users of FreeBSD identified a need to run the NFS server inside a vnet prison.
 This turned into a small project, where I now have a patch that does this.
-It is currently available at the above link for testing or on Phabricator as https://reviews.freebsd.org/D37519[D37519].
+It is currently available at the above link for testing or on Phabricator as link:https://reviews.freebsd.org/D37519[D37519].
 Without this patch, the NFS server cannot be run in a prison.
 
 Not included in the above patch is the ability to run the man:rpc.tlsservd[8] and man:nfsuserd[8] daemons within the vnet prison.

--- a/2022q4/NFS-in-prisons.adoc
+++ b/2022q4/NFS-in-prisons.adoc
@@ -1,21 +1,21 @@
 === Enable the NFS server to run in a vnet prison
 
 Links: +
-link:https://people.freebsd.org/~rmacklem/vnet.patch[Source patch for main] URL: link:https://people.freebsd.org/~rmacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
-link:https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: link:https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
+https://people.freebsd.org/~rmacklem/vnet.patch[Source patch for main] URL: https://people.freebsd.org/~rmacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
+https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
 
 Contact: Rick Macklem <rmacklem@freebsd.org>
 
 Several users of FreeBSD identified a need to run the NFS server inside a vnet prison.
 This turned into a small project, where I now have a patch that does this.
-It is currently available at the above link for testing or on phabricator as link:https://reviews.freebsd.org/D37519[D37519].
+It is currently available at the above link for testing or on Phabricator as https://reviews.freebsd.org/D37519[D37519].
 Without this patch, the NFS server cannot be run in a prison.
 
-Not included in the above patch is the ability to run the man:rpc.tlsservd[8] or man:nfsuserd[8] daemons within the vnet prison.
+Not included in the above patch is the ability to run the man:rpc.tlsservd[8] and man:nfsuserd[8] daemons within the vnet prison.
 I do now have patches that allow these daemons to run in the vnet prison along with man:mountd[8] and man:nfsd[8], but I would like to get the above patch into main before adding support for man:rpc.tlsservd[8] or man:nfsuserd[8].
 
 At this time, the code needs reviewing and testing.
-Hopefully this can be completed in the next few weeks, so that the patch can be committed to `main` and possibly also MFC'd to stable/13.
+Hopefully this can be completed in the next few weeks, so that the patch can be committed to `main` and possibly also MFC'd to `stable/13`.
 
 ==== To do
 

--- a/2022q4/NFS-in-prisons.adoc
+++ b/2022q4/NFS-in-prisons.adoc
@@ -1,8 +1,8 @@
 === Enable the NFS server to run in a vnet prison
 
 Links: +
-https://people.freebsd.org/~rmacklem/vnet.patch[Source patch for main] URL: link:https://people.freebsd.org/~rmacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
-https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: link:https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
+link:https://people.freebsd.org/%7Ermacklem/vnet.patch[Source patch for main] URL: link:https://people.freebsd.org/%7Ermacklem/vnet.patch[https://people.freebsd.org/~rmacklem/vnet.patch] +
+link:https://people.freebsd.org/%7Ermacklem/nfsd-vnet-prison-setup.txt[Simple Setup Doc] URL: link:https://people.freebsd.org/%7Ermacklem/nfsd-vnet-prison-setup.txt[https://people.freebsd.org/~rmacklem/nfsd-vnet-prison-setup.txt]
 
 Contact: Rick Macklem <rmacklem@freebsd.org>
 


### PR DESCRIPTION
Grammar: daemons (two, plural), so 'and' (not 'or'). A cursory glance at <https://www.freebsd.org/cgi/man.cgi?query=rpc.tlsservd&sektion=8&manpath=FreeBSD> and <https://www.freebsd.org/cgi/man.cgi?query=nfsuserd&sektion=8&manpath=FreeBSD> suggests that the two are not mutually exclusive. 

Whilst here: 

* uppercase P for Phabricator
* the markup applied to one branch should also apply to the other branch that's mentioned in the same sentence
* superfluous link: prefixes.