### PR TITLE
pantheon: package macro, and suggested changes

### DIFF
--- a/2022q4/pantheon.adoc
+++ b/2022q4/pantheon.adoc
@@ -2,7 +2,7 @@
 
 Links: +
 link:https://elementary.io/[elementary OS] URL: link:https://elementary.io/[https://elementary.io] +
-link:https://codeberg.org/olivierd/freebsd-ports-elementary[Development repository] URL: link:https://codeberg.org/olivierd/freebsd-ports-elementary[https://codeberg.org/olivierd/freebsd-ports-elementary] +
+link:https://codeberg.org/olivierd/freebsd-ports-elementary[Development repository] URL: link:https://codeberg.org/olivierd/freebsd-ports-elementary[https://codeberg.org/olivierd/freebsd-ports-elementary]
 
 Contact: Olivier Duchateau <duchateau.olivier@gmail.com>
 
@@ -10,32 +10,32 @@ The Pantheon desktop environment is designed for elementary OS.
 It builds on GNOME technologies (such as Mutter, GTK 3 and 4) and it is written in Vala.
 The goal is to have a new desktop for users.
 
-*13.1-RELEASE or higher is required*, because several core components depend on `deskutils/xdg-desktop-portal`.
+*13.1-RELEASE or higher is required*, because several core components depend on package:deskutils/xdg-desktop-portal[].
 
-The repository contains Mk/Uses framework `elementary.mk`, official applications, and curated ports which depend on `x11-toolkits/granite`.
+The repository contains Mk/Uses framework `elementary.mk`, official applications, and curated ports which depend on package:x11-toolkits/granite[].
 
 Since the previous report, we have been updating its related ports, especially:
 
-* `deskutils/elementary-calendar` update to link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267797[6.1.2]
-* `deskutils/iconbrowser`
-* `graphics/elementary-photos`
-* `math/elementary-calculator`
-* `multimedia/elementary-videos`
-* `x11/elementary-terminal`
-* `x11-themes/gnome-icons-elementary`
-* `x11-toolkits/granite7`.
+* package:deskutils/elementary-calendar[] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267797[update to 6.1.2]
+* package:deskutils/iconbrowser[]
+* package:graphics/elementary-photos[]
+* package:math/elementary-calculator[]
+* package:multimedia/elementary-videos[]
+* package:x11/elementary-terminal[]
+* package:x11-themes/gnome-icons-elementary[]
+* package:x11-toolkits/granite7[].
 
 Power manager plugins for top panel (wingpanel) and control center (switchboard) are finished.
 
-A new switchboard plugin is also available, `net/switchboard-plug-sharing`.
+A new switchboard plugin is also available, package:net/switchboard-plug-sharing[].
 Ported *Rygel*, GNOME UPnP/DLNA services.
 
 Submitted other patches for low level libraries such as:
 
-* `print/cups-pk-helper` update to link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266067[0.2.7] required by `print/switchboard-plus-printers`
-* `devel/libgee` update to link:https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266585[0.20.6] heavily uses by the desktop
-* `sysutils/polkit` update to 122 link:https://reviews.freebsd.org/D37137[D37137]
-* `sysutils/accountsservice` update to 22.08.8 link:https://reviews.freebsd.org/D37679[D37679].
+* package:print/cups-pk-helper[] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266067[update to 0.2.7] required by package:print/switchboard-plus-printers[]
+* package:devel/libgee[] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266585[update to 0.20.6] heavily used by the desktop
+* package:sysutils/polkit[] update to 122 link:https://reviews.freebsd.org/D37137[D37137]
+* package:sysutils/accountsservice[] update to 22.08.8 link:https://reviews.freebsd.org/D37679[D37679].
 
 ==== Open tasks
 

--- a/2022q4/pantheon.adoc
+++ b/2022q4/pantheon.adoc
@@ -34,8 +34,8 @@ Submitted other patches for low level libraries such as:
 
 * package:print/cups-pk-helper[] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266067[update to 0.2.7] required by package:print/switchboard-plus-printers[]
 * package:devel/libgee[] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266585[update to 0.20.6] heavily used by the desktop
-* package:sysutils/polkit[] update to 122 link:https://reviews.freebsd.org/D37137[D37137]
-* package:sysutils/accountsservice[] update to 22.08.8 link:https://reviews.freebsd.org/D37679[D37679].
+* package:sysutils/polkit[] update to 122 (https://reviews.freebsd.org/D37137[D37137])
+* package:sysutils/accountsservice[] update to 22.08.8 (https://reviews.freebsd.org/D37679[D37679]).
 
 ==== Open tasks
 


### PR DESCRIPTION
Use the package macro, to provide links to ports. 

Whilst here: 

* improve the wording of some of what's linked
* grammar (heavily uses by)
* Phabricator references in parentheses. 